### PR TITLE
[FE-36] Device 목록 조회 API 연동

### DIFF
--- a/apps/ceo-front/src/app/devices/page.tsx
+++ b/apps/ceo-front/src/app/devices/page.tsx
@@ -1,35 +1,42 @@
 'use client';
 
+import { ceoDeviceApi } from '@repo/api/devices';
+import { useQuery } from '@tanstack/react-query';
 const DevicesPage = () => {
+  const { data: ceoDeviceResponse, isLoading } = useQuery({
+    queryKey: ['ceoDevice'],
+    queryFn: () => ceoDeviceApi.getCeoDeviceList(0, 10, 1), //FIXME: storeId 추후 수정
+  });
+
+  if (isLoading) {
+    return <div className='p-4'>로딩 중...</div>;
+  }
+
+  const deviceList = ceoDeviceResponse?.data?.list ?? [];
+
   return (
     <div className='flex flex-col h-full w-full p-3 bg-white'>
       <h1 className='text-2xl font-bold text-gray-800 mb-4'>기기관리</h1>
       <div className='flex flex-col justify-center items-start w-full gap-5'>
         <div className='flex flex-col border w-full p-3 gap-5'>
-          <div>
-            <p>device-R21322232</p>
-            <p>ipad-12(OS 1.2.1)</p>
-          </div>
-          <div className='flex justify-between items-center'>
-            <div>웨이팅 - 관리</div>
-            <div className='text-right'>
-              <p>설치 일자 2025-02-01 23:23:12</p>
-              <p>마지막 접속 일자 2025-02-01 23:23:12</p>
+          {deviceList.map((device) => (
+            <div key={device.id} className='flex flex-col border w-full p-3 gap-5'>
+              <div>
+                <p>{device.name}</p>
+                <p>
+                  {device.deviceType} (OS {device.osVersion})
+                </p>
+              </div>
+              <div className='flex justify-between items-center'>
+                <div>{device.serviceType}</div>
+                <div className='text-right'>
+                  <p>설치 일자 {device.installedAt}</p>
+                  <p>마지막 접속 일자 {device.lastConnectedAt}</p>
+                </div>
+              </div>
             </div>
-          </div>
-        </div>
-        <div className='flex flex-col border w-full p-3'>
-          <div>
-            <p>device-R21322232</p>
-            <p>ipad-12(OS 1.2.1)</p>
-          </div>
-          <div className='flex justify-between items-center'>
-            <div>웨이팅 - 접수</div>
-            <div className='text-right'>
-              <p>설치 일자 2025-02-01 23:23:12</p>
-              <p>마지막 접속 일자 2025-02-01 23:23:12</p>
-            </div>
-          </div>
+          ))}
+          {deviceList.length === 0 && <p className='text-gray-500'>등록된 기기가 없습니다.</p>}
         </div>
       </div>
     </div>

--- a/apps/ceo-front/src/app/layout.tsx
+++ b/apps/ceo-front/src/app/layout.tsx
@@ -3,7 +3,6 @@ import './globals.css';
 import Script from 'next/script';
 import { ReactNode, Suspense } from 'react';
 
-import { QueryClient } from '@tanstack/react-query';
 import { Metadata } from 'next';
 
 import { Providers } from './providers';
@@ -15,8 +14,6 @@ export const metadata: Metadata = {
   title: '푸딩 사장님 사이트',
   icons: [{ rel: 'icon', url: '/favicon.ico' }],
 };
-
-export const queryClient = new QueryClient();
 
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (

--- a/apps/ceo-front/src/app/layout.tsx
+++ b/apps/ceo-front/src/app/layout.tsx
@@ -3,8 +3,10 @@ import './globals.css';
 import Script from 'next/script';
 import { ReactNode, Suspense } from 'react';
 
+import { QueryClient } from '@tanstack/react-query';
 import { Metadata } from 'next';
 
+import { Providers } from './providers';
 import Analytics from '@/components/GA/Analytics';
 import Layout from '@/components/Home/Layout';
 import { GA_TRACKING_ID } from '@/libs/ga/gtag';
@@ -14,20 +16,24 @@ export const metadata: Metadata = {
   icons: [{ rel: 'icon', url: '/favicon.ico' }],
 };
 
+export const queryClient = new QueryClient();
+
 export default function RootLayout({ children }: { children: ReactNode }) {
   return (
     <html lang='en'>
-      {process.env.NODE_ENV === 'production' && (
-        <>
-          <Script
-            strategy='afterInteractive'
-            src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
-          />
-          <Script
-            id='gtag-init'
-            strategy='afterInteractive'
-            dangerouslySetInnerHTML={{
-              __html: `
+      <head />
+      <body>
+        {process.env.NODE_ENV === 'production' && (
+          <>
+            <Script
+              strategy='afterInteractive'
+              src={`https://www.googletagmanager.com/gtag/js?id=${GA_TRACKING_ID}`}
+            />
+            <Script
+              id='gtag-init'
+              strategy='afterInteractive'
+              dangerouslySetInnerHTML={{
+                __html: `
                   window.dataLayer = window.dataLayer || [];
                   function gtag(){dataLayer.push(arguments);}
                   gtag('js', new Date());
@@ -35,17 +41,19 @@ export default function RootLayout({ children }: { children: ReactNode }) {
                     page_path: window.location.pathname,
                   });
                 `,
-            }}
-          />
-        </>
-      )}
-      <body>
-        <Suspense>
-          <Layout>
-            {children}
-            <Analytics />
-          </Layout>
-        </Suspense>
+              }}
+            />
+          </>
+        )}
+
+        <Providers>
+          <Suspense fallback={<div>페이지를 불러오는 중입니다...</div>}>
+            <Layout>
+              {children}
+              <Analytics />
+            </Layout>
+          </Suspense>
+        </Providers>
       </body>
     </html>
   );

--- a/apps/ceo-front/src/app/providers.tsx
+++ b/apps/ceo-front/src/app/providers.tsx
@@ -1,0 +1,11 @@
+'use client';
+
+import { ReactNode } from 'react';
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+export const queryClient = new QueryClient();
+
+export function Providers({ children }: { children: ReactNode }) {
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -4,7 +4,8 @@
   "private": true,
   "exports": {
     "./example": "./src/example/index.ts",
-    "./stores": "./src/stores/index.ts"
+    "./stores": "./src/stores/index.ts",
+    "./devices": "./src/devices/index.ts"
   },
   "scripts": {
     "format": "prettier --cache --write .",

--- a/packages/api/src/devices/index.ts
+++ b/packages/api/src/devices/index.ts
@@ -1,0 +1,27 @@
+import { api } from '../shared';
+import { PageResponseSchema } from './type';
+
+export const ceoDeviceApi = {
+  getCeoDeviceList: async (
+    page: number = 0,
+    size: number = 10,
+    storeId: number,
+    searchString?: string,
+  ) => {
+    const params = new URLSearchParams({
+      pageNum: (page + 1).toString(),
+      pageSize: size.toString(),
+    });
+
+    if (storeId !== undefined) {
+      params.append('storeId', storeId.toString());
+    }
+
+    if (searchString) {
+      params.append('searchString', searchString);
+    }
+
+    const response = await api.get(`/ceo/devices?${params.toString()}`);
+    return PageResponseSchema.parse(response);
+  },
+};

--- a/packages/api/src/devices/type.ts
+++ b/packages/api/src/devices/type.ts
@@ -1,0 +1,25 @@
+import z from 'zod';
+
+import { createPageResponseSchema } from '../shared';
+
+export const CeoDeviceResponseSchema = z.object({
+  id: z.number(),
+  deviceType: z.string(),
+  name: z.string(),
+  osVersion: z.string(),
+  installedAt: z.string(),
+  lastConnectedAt: z.string(),
+  serviceType: z.string(),
+});
+
+export const CeoDeviceConnnectRequestSchema = z.object({
+  name: z.string(),
+  type: z.string(),
+  osVersion: z.string(),
+  appVersion: z.string(),
+  packageName: z.string(),
+  deviceId: z.number(),
+  userId: z.number(),
+});
+
+export const PageResponseSchema = createPageResponseSchema(CeoDeviceResponseSchema);

--- a/packages/api/src/shared.ts
+++ b/packages/api/src/shared.ts
@@ -60,8 +60,30 @@ export const createApi = (apiClient: AxiosInstance) => ({
 
 export const api = createApi(apiClient);
 
-export const ApiResponse = <TData extends ZodType>(data: TData) =>
+export const ApiResponse = <TData extends ZodType>(data: TData) => {
   z.object({
     status: z.string(),
     data: data,
   });
+};
+
+export const PageInfoSchema = z.object({
+  pageNum: z.number(),
+  pageSize: z.number(),
+  totalCount: z.number(),
+  totalPages: z.number(),
+});
+
+export const createPageResponseSchema = <T extends z.ZodTypeAny>(itemSchema: T) =>
+  z.object({
+    status: z.string(),
+    data: z.object({
+      list: z.array(itemSchema),
+      pageInfo: PageInfoSchema,
+    }),
+  });
+
+export type PageResponse<T extends z.ZodTypeAny> = z.infer<
+  ReturnType<typeof createPageResponseSchema<T>>
+>;
+export type PageInfo = z.infer<typeof PageInfoSchema>;

--- a/packages/api/src/stores/index.ts
+++ b/packages/api/src/stores/index.ts
@@ -3,13 +3,11 @@ export * from './type';
 import { api } from '../shared';
 import {
   AdminCreateStoreRequest,
-  AdminStoreResponse,
   AdminUpdateStoreRequest,
-  PageResponse,
   SortDirection,
   StoreSortType,
-  PageResponseSchema,
   AdminStoreResponseSchema,
+  PageResponseSchema,
 } from './type';
 
 const ENDPOINT = '/admin/stores';
@@ -19,7 +17,7 @@ export const storeApi = {
     page: number = 0,
     size: number = 10,
     sortType: StoreSortType = 'RECENT',
-    sortDirection: SortDirection = 'DESCENDING'
+    sortDirection: SortDirection = 'DESCENDING',
   ) => {
     const params = new URLSearchParams({
       pageNum: (page + 1).toString(),
@@ -50,4 +48,4 @@ export const storeApi = {
   deleteStore: async (id: number) => {
     return api.delete(`${ENDPOINT}/${id}`);
   },
-}; 
+};

--- a/packages/api/src/stores/type.ts
+++ b/packages/api/src/stores/type.ts
@@ -1,17 +1,19 @@
 import { z } from 'zod';
 
+import { createPageResponseSchema } from '../shared';
+
 export const StoreSortType = {
   RECENT: 'RECENT',
 } as const;
 
-export type StoreSortType = typeof StoreSortType[keyof typeof StoreSortType];
+export type StoreSortType = (typeof StoreSortType)[keyof typeof StoreSortType];
 
 export const SortDirection = {
   ASCENDING: 'ASCENDING',
   DESCENDING: 'DESCENDING',
 } as const;
 
-export type SortDirection = typeof SortDirection[keyof typeof SortDirection];
+export type SortDirection = (typeof SortDirection)[keyof typeof SortDirection];
 
 export const AdminStoreResponseSchema = z.object({
   id: z.number(),
@@ -62,22 +64,8 @@ export const AdminUpdateStoreRequestSchema = z.object({
   isTakeOut: z.boolean(),
 });
 
-export const PageInfoSchema = z.object({
-  pageNum: z.number(),
-  pageSize: z.number(),
-  totalCount: z.number(),
-  totalPages: z.number(),
-});
-
-export const PageResponseSchema = z.object({
-  status: z.string(),
-  data: z.object({
-    list: z.array(AdminStoreResponseSchema),
-    pageInfo: PageInfoSchema,
-  }),
-});
+export const PageResponseSchema = createPageResponseSchema(AdminStoreResponseSchema);
 
 export type AdminStoreResponse = z.infer<typeof AdminStoreResponseSchema>;
 export type AdminCreateStoreRequest = z.infer<typeof AdminCreateStoreRequestSchema>;
 export type AdminUpdateStoreRequest = z.infer<typeof AdminUpdateStoreRequestSchema>;
-export type PageResponse = z.infer<typeof PageResponseSchema>; 


### PR DESCRIPTION
<!-- 제목: [FE-00] 이슈 제목 -->

## 🎫 관련 티켓
<!-- [이슈 제목](노션 링크) -->
[[FE-36] Device 목록 조회 API 연동](https://www.notion.so/benkang/CEO-Device-API-1d783feabad380628cb3e23bb1e26ea6?pvs=4)
<br />

## 📝 요약(Summary)

<br />

## 🛠️ PR 유형
<!-- 해당 항목에 'x'를 입력하면 체크됩니다. -->
- [x] 기능 추가
- [ ] 버그 수정
- [ ] UI 수정 (스타일, 레이아웃 등)
- [ ] 리팩토링 (동작 변경 없음)
- [ ] 문서 또는 주석 수정
- [ ] 테스트 코드 추가/수정
- [ ] 기타 구조 변경 (폴더명, 빌드 설정 등)  
<br />

## 📸스크린샷 (Optional)

<br />

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
- 현재 storeId 값이 없어 목록이 나오지 않습니다. (추후 CEO 페이지 로그인 후 storeId 가져오기 필요)
- react-query를 이용하여 API 연동 해두었습니다. 쿼리에 관해서 논의 필요할 것 같습니다!
- ceo관련된 deviceAPI인데 일단은 폴더명을 devices로 해두었습니다.. 
- deviceAPI가 많아 이것도 나눌지 device에 관련한 API는 전부 모을지 논의 해보면 좋을 것 같습니다
<br />
