### PR TITLE
chore: 리워드 메인 > 휴대폰 번호 다 입력 시에 리워드 사용하기 버튼 활성화

### DIFF
--- a/apps/app-front/src/app/store/reward/page.tsx
+++ b/apps/app-front/src/app/store/reward/page.tsx
@@ -102,7 +102,7 @@ export default function WaitingPage() {
             <div className='headline-3-2 text-black whitespace-nowrap mt-5 mb-15'>
               휴대폰 번호를 입력해주세요
             </div>
-            <Button size='sm' variant='secondary' onClick={() => router.push('/store/reward/use')}>
+            <Button size='sm' variant={phoneNumber?.length >= 13 ? 'secondary' : 'disabled'} onClick={() => router.push('/store/reward/use')}>
               리워드 사용하기
             </Button>
           </div>


### PR DESCRIPTION
<!-- 제목: [FE-00] 이슈 제목 -->

## 🎫 관련 티켓
<!-- [이슈 제목](노션 링크) -->
<br />

## 📝 요약(Summary)
리워드 메인(/store/reward) 페이지에서 휴대폰 번호 다 입력 시에만 '리워드 사용하기' 버튼이 활성화되도록 수정했습니다.
<br />

## 🛠️ PR 유형
<!-- 해당 항목에 'x'를 입력하면 체크됩니다. -->
- [ ] 기능 추가
- [ ] 버그 수정
- [x] UI 수정 (스타일, 레이아웃 등)
- [ ] 리팩토링 (동작 변경 없음)
- [ ] 문서 또는 주석 수정
- [ ] 테스트 코드 추가/수정
- [ ] 기타 구조 변경 (폴더명, 빌드 설정 등)  
<br />

## 📸스크린샷 (Optional)
<img width="931" alt="image" src="https://github.com/user-attachments/assets/30dd33e1-9021-465b-96a4-2099e42f44a1" />
휴대폰 번호 덜 입력했을 때 -> '리워드 사용하기' 버튼 비활성화
<img width="933" alt="image" src="https://github.com/user-attachments/assets/9b023809-6b88-4d56-b683-0e3f8e5ba839" />
휴대폰 번호 다 입력해했을 때 -> '리워드 사용하기' 버튼 활성화
<br />

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<br />