### PR TITLE
[FE-144] 적립 내역 api 10초마다 polling하여 호출

### DIFF
--- a/apps/app-front/src/app/store/reward/use/page.tsx
+++ b/apps/app-front/src/app/store/reward/use/page.tsx
@@ -55,13 +55,11 @@ export default function RewardUsePage() {
     enabled: !!storeId && !!phoneNumber && mainTab === 'coupon',
   });
 
-  const {
-    data: rewardLogData,
-    isLoading: isLogLoading,
-  } = useQuery<UserRewardLogsResponse>({
+  const { data: rewardLogData, isLoading: isLogLoading } = useQuery<UserRewardLogsResponse>({
     queryKey: [queryKeys.app.reward.coupons],
     queryFn: () => rewardApi.getLog(commonParams),
     enabled: !!storeId && !!phoneNumber && mainTab === 'history',
+    refetchInterval: 10000,
   });
 
   const handleClickCoupon = async () => {
@@ -99,10 +97,7 @@ export default function RewardUsePage() {
         </main>
       )}
       {mainTab === 'history' && (
-        <RewardHistory
-          rewards={rewardLogData?.data.content ?? []}
-          isLoading={isLogLoading}
-        />
+        <RewardHistory rewards={rewardLogData?.data.content ?? []} isLoading={isLogLoading} />
       )}
       <CouponUseModal
         open={selectedCouponId !== null}


### PR DESCRIPTION
<!-- 제목: [FE-00] 이슈 제목 -->

## 🎫 관련 티켓
[적립 내역 api polling 호출](https://www.notion.so/benkang/1ca83feabad380859559d59a6f323790?v=1ca83feabad3800fac18000cac82606b&p=21f83feabad380d9bcede51f3766fa3b&pm=s)
<br />

## 📝 요약(Summary)
10초마다 API polling 되도록 refetchInterval 옵션 추가했습니다.
시간 조정이 필요하다면 말씀 부탁드립니다~
<br />

## 🛠️ PR 유형
<!-- 해당 항목에 'x'를 입력하면 체크됩니다. -->
- [x] 기능 추가
- [ ] 버그 수정
- [ ] UI 수정 (스타일, 레이아웃 등)
- [ ] 리팩토링 (동작 변경 없음)
- [ ] 문서 또는 주석 수정
- [ ] 테스트 코드 추가/수정
- [ ] 기타 구조 변경 (폴더명, 빌드 설정 등)  
<br />

## 📸스크린샷 (Optional)

<br />

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<br />
