### PR TITLE
[user-front] chore: 설정 페이지 클릭 영역 개선

### DIFF
--- a/apps/user-front/src/screens/settings/Settings.tsx
+++ b/apps/user-front/src/screens/settings/Settings.tsx
@@ -7,6 +7,7 @@ import BottomTab from '@/components/Layout/BottomTab';
 import { Header } from '@/components/Layout/Header';
 import { Screen } from '@/components/Layout/Screen';
 import { useAuth } from '@/components/Provider/AuthProvider';
+import { cn } from '@/utils/cn';
 
 export const SettingScreen: ActivityComponentType<'SettingScreen'> = () => {
   const { logout } = useAuth();
@@ -23,52 +24,91 @@ export const SettingScreen: ActivityComponentType<'SettingScreen'> = () => {
       bottomTab={<BottomTab currentTab='mypage' />}
     >
       <div className='flex flex-col justify-baseline items-baseline body-3'>
-        <div className='flex flex-col w-full gap-8 px-grid-margin py-grid-margin'>
-          <p className='body-6 text-gray-5'>계정</p>
-          <button className='flex justify-between'>
-            <span>프로필 수정</span>
-            <ChevronRightIcon size={24} className='cursor-pointer text-gray-5' />
-          </button>
-          <button className='flex justify-between'>
-            <span>내정보 수정</span>
-            <ChevronRightIcon size={24} className='cursor-pointer text-gray-5' />
-          </button>
-        </div>
+        <MenuItemGroup label={<MenuItemGroupLabel>계정</MenuItemGroupLabel>}>
+          <MenuItem>
+            <MenuItemText>프로필 수정</MenuItemText>
+            <MenuItemChevronRight />
+          </MenuItem>
+          <MenuItem>
+            <MenuItemText>내정보 수정</MenuItemText>
+            <MenuItemChevronRight />
+          </MenuItem>
+        </MenuItemGroup>
         <hr className='w-full text-white bg-gray-1 h-[10px]' />
-        <div className='flex flex-col w-full gap-7 px-grid-margin py-grid-margin'>
-          <p className='body-6 text-gray-5'>서비스 이용</p>
-          <button className='flex justify-between'>
-            <span>알림 설정</span>
-            <ChevronRightIcon
-              size={24}
-              className='cursor-pointer text-gray-5'
-              onClick={() => flow.push('NotificationSettingScreen', {})}
-            />
-          </button>
-          <button className='flex justify-between'>
-            <span>1:1 문의</span>
-            <ChevronRightIcon size={24} className='cursor-pointer text-gray-5' />
-          </button>
-        </div>
+        <MenuItemGroup label={<MenuItemGroupLabel>서비스 이용</MenuItemGroupLabel>}>
+          <MenuItem onClick={() => flow.push('NotificationSettingScreen', {})}>
+            <MenuItemText>알림 설정</MenuItemText>
+            <MenuItemChevronRight />
+          </MenuItem>
+          <MenuItem>
+            <MenuItemText>1:1 문의</MenuItemText>
+            <MenuItemChevronRight />
+          </MenuItem>
+        </MenuItemGroup>
         <hr className='w-full text-white bg-gray-1 h-[10px]' />
-        <div className='flex flex-col w-full gap-7 px-grid-margin py-grid-margin'>
-          <p className='body-6 text-gray-5 mb-3'>기타</p>
-          <button className='flex justify-between'>
-            <span>공지사항 및 이용약관</span>
-            <ChevronRightIcon size={24} className='cursor-pointer text-gray-5' />
-          </button>
-          <button className='flex justify-between'>
-            <span>개선 제안</span>
-            <ChevronRightIcon size={24} className='cursor-pointer text-gray-5' />
-          </button>
-        </div>
-        <div className='flex flex-col gap-7 px-grid-margin py-grid-margin'>
-          <button className='flex justify-between cursor-pointer' onClick={handleLogoutClick}>
-            로그아웃
-          </button>
-          <button className='flex justify-between cursor-pointer'>회원탈퇴</button>
-        </div>
+        <MenuItemGroup label={<MenuItemGroupLabel>기타</MenuItemGroupLabel>}>
+          <MenuItem>
+            <MenuItemText>공지사항 및 이용약관</MenuItemText>
+            <MenuItemChevronRight />
+          </MenuItem>
+          <MenuItem>
+            <MenuItemText>개선 제안</MenuItemText>
+            <MenuItemChevronRight />
+          </MenuItem>
+          <MenuItem onClick={handleLogoutClick}>로그아웃</MenuItem>
+          <MenuItem>회원탈퇴</MenuItem>
+        </MenuItemGroup>
       </div>
     </Screen>
   );
+};
+
+type MenuItemGroupProps = React.ComponentPropsWithRef<'div'> & {
+  label: React.ReactNode;
+};
+
+const MenuItemGroup = ({ className, children, label, ...props }: MenuItemGroupProps) => {
+  return (
+    <div className={cn('flex flex-col w-full pt-5 pb-3', className)} {...props}>
+      {label}
+      {children}
+    </div>
+  );
+};
+
+type MenuItemGroupLabelProps = React.ComponentPropsWithRef<'span'>;
+
+const MenuItemGroupLabel = ({ className, children, ...props }: MenuItemGroupLabelProps) => {
+  return (
+    <span className={cn('body-6 text-gray-5 px-grid-margin pb-3', className)} {...props}>
+      {children}
+    </span>
+  );
+};
+
+type MenuItemProps = React.ComponentPropsWithRef<'button'>;
+
+const MenuItem = ({ className, children, ...props }: MenuItemProps) => {
+  return (
+    <button
+      className={cn('flex justify-between py-[18px] px-grid-margin active:bg-gray-1', className)}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+type MenuItemLabelProps = React.ComponentPropsWithRef<'span'>;
+
+const MenuItemText = ({ className, children, ...props }: MenuItemLabelProps) => {
+  return (
+    <span className={cn('text-base', className)} {...props}>
+      {children}
+    </span>
+  );
+};
+
+const MenuItemChevronRight = () => {
+  return <ChevronRightIcon size={24} className='cursor-pointer text-gray-5' />;
 };


### PR DESCRIPTION
<!-- 제목: [FE-00] 이슈 제목 -->

## 🎫 관련 티켓
<!-- [이슈 제목](노션 링크) -->
<br />

## 📝 요약(Summary)

- 기존 화살표로 제한된 클릭영역을 row 전체로 확장 (스크린샷에서 회색 부분이 클릭 영역)
- 메뉴 영역 UI를 MenuItem 컴포넌트로 구조화

<br />

## 🛠️ PR 유형
<!-- 해당 항목에 'x'를 입력하면 체크됩니다. -->
- [ ] 기능 추가
- [ ] 버그 수정
- [x] UI 수정 (스타일, 레이아웃 등)
- [ ] 리팩토링 (동작 변경 없음)
- [ ] 문서 또는 주석 수정
- [ ] 테스트 코드 추가/수정
- [ ] 기타 구조 변경 (폴더명, 빌드 설정 등)  
<br />

## 📸스크린샷 (Optional)

<img width="493" height="783" alt="스크린샷 2025-07-15 오후 4 50 46" src="https://github.com/user-attachments/assets/5ebc3cde-5a33-4248-b9dc-67a52c5a16b2" />


<br />

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<br />
