### PR TITLE
[FE-178] USER 가게상세 리뷰 수정

### DIFF
--- a/apps/user-front/next.config.ts
+++ b/apps/user-front/next.config.ts
@@ -5,7 +5,7 @@ const nextConfig: NextConfig = {
     ignoreDuringBuilds: true,
   },
   images: {
-    domains: ['img.freepik.com'],
+    domains: ['img.freepik.com', 'd27gz6v6wvae1d.cloudfront.net'],
   },
 };
 

--- a/apps/user-front/src/components/Store/ReviewCard.tsx
+++ b/apps/user-front/src/components/Store/ReviewCard.tsx
@@ -27,9 +27,21 @@ export const ReviewCard = ({ review }: ReviewCardProps) => {
 
       <div className='flex flex-col pt-3 px-5 pb-10'>
         <div className='flex mb-3'>
-          <div className='flex justify-center items-center size-[56px] bg-gray-1 rounded-full'>
-            <FoodingIcon width={25} height={31} color='rgba(17, 17, 17, 0.1)' />
-          </div>
+          {review.profileUrl ? (
+            <div className='flex justify-center items-center w-[56px] h-[56px]'>
+              <Image
+                src={review.profileUrl}
+                alt='프로필 이미지'
+                width={56}
+                height={56}
+                className='w-full h-full object-cover rounded-full'
+              />
+            </div>
+          ) : (
+            <div className='flex bg-gray-1 justify-center items-center rounded-full w-[56px] h-[56px]'>
+              <FoodingIcon width={32} height={40} color='rgba(17, 17, 17, 0.1)' />
+            </div>
+          )}
           <div className='ml-3 flex flex-col justify-center flex-1'>
             <span className='subtitle-3 text-black'>{review.nickname ?? '닉네임 1'}</span>
           </div>

--- a/apps/user-front/src/components/Store/ReviewDetailCard.tsx
+++ b/apps/user-front/src/components/Store/ReviewDetailCard.tsx
@@ -1,7 +1,7 @@
 import Image from 'next/image';
 
 import { Review } from '@repo/api/user';
-import { FoodingIcon, HeartIcon, MessageSquareIcon } from '@repo/design-system/icons';
+import { FoodingIcon } from '@repo/design-system/icons';
 
 import { StarRating } from './StarRating';
 import { formatDotDate } from '@/utils/date';
@@ -19,15 +19,17 @@ export const ReviewDetailCard = ({ review }: ReviewCardProps) => {
         <div className='flex'>
           <div className='flex mr-3'>
             {review.profileUrl ? (
-              <Image
-                style={{ objectFit: 'cover', borderRadius: '50%' }}
-                src={review.profileUrl}
-                alt='프로필 이미지'
-                width={40}
-                height={40}
-              />
+              <div className='flex justify-center items-center w-10 h-10'>
+                <Image
+                  src={review.profileUrl}
+                  alt='프로필 이미지'
+                  width={40}
+                  height={40}
+                  className='w-full h-full object-cover rounded-full'
+                />
+              </div>
             ) : (
-              <div className='flex bg-gray-1 justify-center items-center rounded-[50%] w-[40px] h-[40px]'>
+              <div className='flex bg-gray-1 justify-center items-center rounded-full w-10 h-10'>
                 <FoodingIcon width={25} height={28} color='rgba(17, 17, 17, 0.1)' />
               </div>
             )}
@@ -53,34 +55,23 @@ export const ReviewDetailCard = ({ review }: ReviewCardProps) => {
 
       <div className='flex flex-col'>
         <p className='text-gray-5 body-8 my-4'>{review.content}</p>
-        {imageUrls && imageUrls.length > 0 && (
-          <div className='flex h-[140px] justify-between overflow-x-auto scrollbar-hide gap-3'>
-            {imageUrls.length > 1 ? (
-              imageUrls.map((image, idx) => (
-                <Image
-                  key={idx}
-                  width={140}
-                  height={140}
-                  src={image}
-                  alt={`리뷰이미지_${idx}`}
-                  className='rounded-2xl shrink-0'
-                  style={{ objectFit: 'cover' }}
-                />
-              ))
-            ) : imageUrls[0] ? (
+        {imageUrls.length > 0 && (
+          <div className='flex h-[140px] overflow-x-auto scrollbar-hide gap-3'>
+            {imageUrls.map((url, idx) => (
               <Image
+                key={idx}
                 width={140}
                 height={140}
-                src={imageUrls[0]}
-                alt='리뷰이미지'
-                className='rounded-2xl'
+                src={url}
+                alt={`리뷰이미지_${idx}`}
+                className='rounded-2xl shrink-0'
                 style={{ objectFit: 'cover' }}
               />
-            ) : null}
+            ))}
           </div>
         )}
       </div>
-      <div className='flex mt-2 gap-5'>
+      {/* <div className='flex mt-2 gap-5'>
         <div className='flex gap-2'>
           <HeartIcon size={12} />
           <span className='body-7 color-gray-6'>3</span>
@@ -89,7 +80,9 @@ export const ReviewDetailCard = ({ review }: ReviewCardProps) => {
           <MessageSquareIcon size={12} />
           <span className='body-7 color-gray-6'>1</span>
         </div>
-      </div>
+      </div> */}
+
+      {/* TODO: 추후 수정 */}
     </div>
   );
 };

--- a/apps/user-front/src/hooks/file/useUploadFile.ts
+++ b/apps/user-front/src/hooks/file/useUploadFile.ts
@@ -1,0 +1,14 @@
+import { queryKeys } from '@repo/api/configs/query-keys';
+import { fileApi } from '@repo/api/file';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+export const useUploadFile = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: fileApi.upload,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [queryKeys.file.upload] });
+    },
+  });
+};

--- a/apps/user-front/src/hooks/store/useCreateStoreReview.ts
+++ b/apps/user-front/src/hooks/store/useCreateStoreReview.ts
@@ -8,8 +8,8 @@ export const useCreateStoreReview = () => {
   return useMutation({
     mutationFn: storeApi.createStoreReview,
     mutationKey: [queryKeys.user.store.review, 'create'],
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [queryKeys.user.store.review] });
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: [queryKeys.user.store.review, variables.storeId] });
     },
   });
 };

--- a/apps/user-front/src/libs/stackflow/index.ts
+++ b/apps/user-front/src/libs/stackflow/index.ts
@@ -27,7 +27,7 @@ declare module '@stackflow/config' {
     ReservationTab: object;
     MyPageTab: object;
     NotificationListScreen: object;
-    StoreDetailScreen: { storeId: number };
+    StoreDetailScreen: { storeId: number; tab?: string };
     BookmarkListScreen: object;
     MyCouponListScreen: object;
     StorePostDetailScreen: { storePostId: number; storeName: string };

--- a/apps/user-front/src/screens/reviews/reviewCreate.tsx
+++ b/apps/user-front/src/screens/reviews/reviewCreate.tsx
@@ -1,11 +1,7 @@
 'use client';
 
 import { UploadFile } from '@repo/api/file';
-import {
-  CreateStoreReviewBody,
-  mockReservationDetailResponse,
-  mockStoreReviewListResponse,
-} from '@repo/api/user';
+import { CreateStoreReviewBody, mockReservationDetailResponse } from '@repo/api/user';
 import { ActivityComponentType, useFlow } from '@stackflow/react/future';
 
 import { ReviewForm } from './components/ReviewForm';
@@ -28,9 +24,8 @@ export const ReviewCreateScreen: ActivityComponentType<'ReviewCreateScreen'> = (
 }) => {
   //TODO: 예약 API 나오는대로 수정
   const { data: reservation } = mockReservationDetailResponse;
-  const { data: reviews } = mockStoreReviewListResponse;
-  const { user } = useAuth();
   console.log(reservationId);
+  const { user } = useAuth();
   const flow = useFlow();
 
   const { mutateAsync: createReview } = useCreateStoreReview();

--- a/apps/user-front/src/screens/store-detail/StoreDetail.tsx
+++ b/apps/user-front/src/screens/store-detail/StoreDetail.tsx
@@ -49,6 +49,8 @@ export const StoreDetailScreen: ActivityComponentType<'StoreDetailScreen'> = ({ 
     ref: screenRef,
   });
 
+  const initialTab = params.tab ?? 'home';
+
   return (
     <Screen ref={screenRef}>
       <DefaultErrorBoundary>
@@ -57,7 +59,7 @@ export const StoreDetailScreen: ActivityComponentType<'StoreDetailScreen'> = ({ 
         </NavButton>
         <LoadingToggle fallback={<StoreDetailLoadingFallback />}>
           <Suspense clientOnly fallback={<StoreDetailLoadingFallback />}>
-            <StoreDetail storeId={params.storeId} showHeader={showHeader} />
+            <StoreDetail storeId={params.storeId} showHeader={showHeader} initialTab={initialTab} />
           </Suspense>
         </LoadingToggle>
       </DefaultErrorBoundary>
@@ -68,9 +70,10 @@ export const StoreDetailScreen: ActivityComponentType<'StoreDetailScreen'> = ({ 
 type StoreDetailProps = {
   storeId: number;
   showHeader: boolean;
+  initialTab?: string;
 };
 
-const StoreDetail = ({ storeId, showHeader }: StoreDetailProps) => {
+const StoreDetail = ({ storeId, showHeader, initialTab = 'home' }: StoreDetailProps) => {
   const { user } = useAuth();
   const { data: store } = useGetStoreDetail(storeId);
   const loginBottomSheet = useLoginBottomSheet();
@@ -149,7 +152,7 @@ const StoreDetail = ({ storeId, showHeader }: StoreDetailProps) => {
         </div>
       </Section>
       <Section className='mt-[10px] py-[14px]'>
-        <ChipTabs defaultValue='home' scrollable>
+        <ChipTabs defaultValue={initialTab} scrollable>
           <ChipTabs.List>
             <ChipTabs.Trigger value='home'>홈</ChipTabs.Trigger>
             <ChipTabs.Trigger value='news'>소식</ChipTabs.Trigger>
@@ -185,7 +188,7 @@ const StoreDetail = ({ storeId, showHeader }: StoreDetailProps) => {
             fill={isBookmarked ? 'var(--color-primary-pink)' : 'none'}
             onClick={handleBookmarkClick}
           />
-          <span className='subtitle-4 text-black h-[19px]'>{mock.bookmarkCount}</span>
+          <span className='subtitle-4 text-black h-[19px]'>{store.bookmarkCount}</span>
         </button>
         {/* TODO: 줄서기 기능 추가 */}
         <Button>줄서기</Button>

--- a/apps/user-front/src/screens/store-detail/components/tabs/Home.tsx
+++ b/apps/user-front/src/screens/store-detail/components/tabs/Home.tsx
@@ -1,4 +1,4 @@
-import { mockStoreReviewListResponse, StoreInfo } from '@repo/api/user';
+import { StoreInfo } from '@repo/api/user';
 import { Button, EmptyState } from '@repo/design-system/components/b2c';
 import {
   ClockIcon,
@@ -7,6 +7,7 @@ import {
   PhoneIcon,
   TrainIcon,
 } from '@repo/design-system/icons';
+import { useFlow } from '@stackflow/react/future';
 
 import { Section } from '@/components/Layout/Section';
 import { MenuCard } from '@/components/Store/MenuCard';
@@ -15,6 +16,8 @@ import { StoresList } from '@/components/Store/StoresList';
 import { SubwayLineBadge } from '@/components/SubwayLineBadge';
 import { useGetStoreList } from '@/hooks/store/useGetStoreList';
 import { useGetStoreMenuList } from '@/hooks/store/useGetStoreMenuList';
+import { useGetStoreReviewList } from '@/hooks/store/useGetStoreReviewList';
+import { StoreInfoMap } from '@/screens/waiting-detail/components/StoreInfoMap';
 import { noop } from '@/utils/noop';
 
 const mock = {
@@ -30,9 +33,9 @@ type StoreDetailHomeTabProps = {
 };
 
 export const StoreDetailHomeTab = ({ store }: StoreDetailHomeTabProps) => {
+  const flow = useFlow();
   const { data: storeMenus } = useGetStoreMenuList(store.id);
-  // const { data: storeReviews } = useGetStoreReviewList(store.id);
-  const { data: reviews } = mockStoreReviewListResponse; //TODO: 추후 목데이터 제거
+  const { data: reviews } = useGetStoreReviewList(store.id);
   const { data: stores } = useGetStoreList({ sortType: 'RECENT' });
 
   return (
@@ -40,7 +43,7 @@ export const StoreDetailHomeTab = ({ store }: StoreDetailHomeTabProps) => {
       <Section className='mt-[10px] py-[20px] gap-[6px]'>
         <span className='body-6 flex items-center gap-[10px]'>
           <MarkPinIcon className='size-[18px] stroke-1' />
-          {mock.location}
+          {store.address}
         </span>
         <span className='body-6 flex items-center gap-[10px]'>
           <ClockIcon className='size-[18px] stroke-1' />
@@ -83,7 +86,13 @@ export const StoreDetailHomeTab = ({ store }: StoreDetailHomeTabProps) => {
             리뷰
             <span className='subtitle-6 text-gray-5'>({reviews.list.length})</span>
           </Section.Title>
-          {reviews.list.length > 0 && <Section.Link>더보기</Section.Link>}
+          {reviews.list.length > 0 && (
+            <Section.Link
+              onClick={() => flow.push('StoreDetailScreen', { storeId: store.id, tab: 'review' })}
+            >
+              더보기
+            </Section.Link>
+          )}
         </Section.Header>
         {reviews.list.length === 0 && (
           <EmptyState className='mt-10' title='등록된 리뷰가 없어요!' />
@@ -94,21 +103,22 @@ export const StoreDetailHomeTab = ({ store }: StoreDetailHomeTabProps) => {
           </ul>
         )}
       </Section>
-      {/* TODO: 매장 위치 조회 기능 추가 */}
       <Section className='mt-[10px] pb-8'>
         <Section.Header>
           <Section.Title>매장 위치</Section.Title>
         </Section.Header>
-        <div className='mt-[14px] rounded-[12px] bg-gray-1 h-[262px]' />
+        <div className='w-full mt-[14px] rounded-[12px] h-[300px]'>
+          <StoreInfoMap lat={store.latitude} lng={store.longitude} className='rounded-2xl' />
+        </div>
         <div className='mt-3 flex flex-col gap-1'>
           <span className='body-6 flex items-center gap-[10px]'>
             <MarkPinIcon className='size-[18px] stroke-1' />
-            제주 제주시 서해안로 654 바다풍경 정육식당
+            {store.address}
           </span>
           <span className='body-6 flex items-center'>
             <TrainIcon className='mr-[10px] size-[18px] stroke-1' />
             <SubwayLineBadge className='mr-1' line={6} />
-            제주역에서 847m
+            {store.direction}
           </span>
         </div>
         <Button className='mt-5' variant='gray'>

--- a/apps/user-front/src/screens/store-detail/components/tabs/ReviewDetail.tsx
+++ b/apps/user-front/src/screens/store-detail/components/tabs/ReviewDetail.tsx
@@ -1,28 +1,33 @@
-import { mockStoreReviewListResponse, StoreInfo } from '@repo/api/user';
+import { StoreInfo } from '@repo/api/user';
 import { EmptyState } from '@repo/design-system/components/b2c';
 import { ChevronDownIcon, StarIcon } from '@repo/design-system/icons';
 
 import { Section } from '@/components/Layout/Section';
 import { ReviewsDetailList } from '@/components/Store/ReviewsDetailList';
 import { useGetStoreDetail } from '@/hooks/store/useGetStoreDetail';
+import { useGetStoreReviewList } from '@/hooks/store/useGetStoreReviewList';
 import { getRatingRatios, RatingRatio } from '@/utils/rating';
 
 type StoreDetailReviewTabProps = {
   store: StoreInfo;
 };
 
-// FIXME: 가게상세 리뷰 API 나오면 수정
 export const StoreDetailReviewTab = ({ store }: StoreDetailReviewTabProps) => {
   const { data: storeInfo } = useGetStoreDetail(store.id);
-  const { data: reviews } = mockStoreReviewListResponse;
+  const { data: reviews } = useGetStoreReviewList(store.id);
 
-  const ratingCounts = {
-    5: 240,
-    4: 15,
-    3: 2,
-    2: 0,
-    1: 0,
-  };
+  const ratingCounts: { [score: number]: number } = (() => {
+    const counts: { [score: number]: number } = {};
+
+    if (!reviews?.list) return counts;
+
+    for (const review of reviews.list) {
+      const roundedScore = Math.round(review.score.total);
+      counts[roundedScore] = (counts[roundedScore] ?? 0) + 1;
+    }
+
+    return counts;
+  })();
 
   return (
     <Section className='flex flex-col'>

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -8,6 +8,7 @@
     "./auth": "./src/auth/index.ts",
     "./user": "./src/user/index.ts",
     "./ceo": "./src/ceo/index.ts",
+    "./file": "./src/file/index.ts",
     "./users": "./src/users/index.ts",
     "./configs/storage-keys": "./src/configs/storageKeys.ts",
     "./configs/query-keys": "./src/configs/queryKeys.ts"

--- a/packages/api/src/configs/queryKeys.ts
+++ b/packages/api/src/configs/queryKeys.ts
@@ -48,4 +48,7 @@ export const queryKeys = {
   me: {
     user: 'meUser',
   },
+  file: {
+    upload: 'fileUpload',
+  },
 };

--- a/packages/api/src/file/index.ts
+++ b/packages/api/src/file/index.ts
@@ -1,0 +1,15 @@
+export * from './type';
+
+import { api } from '../shared';
+import { FileUploadResponse } from './type';
+
+export const fileApi = {
+  upload: async (body: FormData) => {
+    const response = await api.post('/file-upload', body, {
+      headers: {
+        'Content-Type': 'multipart/form-data',
+      },
+    });
+    return FileUploadResponse.parse(response);
+  },
+};

--- a/packages/api/src/file/type.ts
+++ b/packages/api/src/file/type.ts
@@ -2,6 +2,7 @@ import z from 'zod/v4';
 
 import { ApiResponse } from '../shared';
 
+export type FileUploadResponse = z.infer<typeof FileUploadResponse>;
 export const FileUploadResponse = ApiResponse(
   z.array(
     z.object({
@@ -12,3 +13,11 @@ export const FileUploadResponse = ApiResponse(
     }),
   ),
 );
+
+export type UploadFile = z.infer<typeof UploadFile>;
+export const UploadFile = z.object({
+  id: z.string(),
+  name: z.string(),
+  size: z.number(),
+  url: z.string(),
+});

--- a/packages/api/src/file/type.ts
+++ b/packages/api/src/file/type.ts
@@ -1,0 +1,14 @@
+import z from 'zod/v4';
+
+import { ApiResponse } from '../shared';
+
+export const FileUploadResponse = ApiResponse(
+  z.array(
+    z.object({
+      id: z.string(),
+      name: z.string(),
+      size: z.number(),
+      url: z.string(),
+    }),
+  ),
+);


### PR DESCRIPTION
<!-- 제목: [FE-00] 이슈 제목 -->

## 🎫 관련 티켓
<!-- [이슈 제목](노션 링크) -->
[[FE-178] USER 가게상세 리뷰 수정](https://www.notion.so/benkang/USER-23d83feabad3805baeb8f9747b8c1a37?v=1ca83feabad380e9ba46000c9293d8eb&source=copy_link)
<br />

## 📝 요약(Summary)
- 가게 상세 페이지 내의 리뷰 리스트, 카드 수정
- 리뷰작성 시 사진 첨부 가능하도록 수정
- 가게상세의 리뷰목록에서 더보기 클릭시 리뷰탭으로 이동
- 가게 상세의 ```averageRating``` 적용이 안되서 문의중 입니다.
<br />

## 🛠️ PR 유형
<!-- 해당 항목에 'x'를 입력하면 체크됩니다. -->
- [ ] 기능 추가
- [x] 버그 수정
- [ ] UI 수정 (스타일, 레이아웃 등)
- [x] 리팩토링 (동작 변경 없음)
- [ ] 문서 또는 주석 수정
- [ ] 테스트 코드 추가/수정
- [ ] 기타 구조 변경 (폴더명, 빌드 설정 등)  
<br />

## 📸스크린샷 (Optional)
<img width="389" height="493" alt="image" src="https://github.com/user-attachments/assets/06174463-22e0-4dd7-a958-a65b4d57fb0f" />
<img width="389" height="695" alt="image" src="https://github.com/user-attachments/assets/a452b735-9d26-4745-a4fe-0bec484e1d9e" />

<br />

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<br />
