### PR TITLE
[fix/FE-180]: 내정보 수정/입력 화면 수정

### DIFF
--- a/apps/user-front/src/components/AuthTab/MyPageLink.tsx
+++ b/apps/user-front/src/components/AuthTab/MyPageLink.tsx
@@ -20,14 +20,20 @@ export const MyPageLink = ({ BottomTabItem, BottomTabLabel, isActive }: MyPageLi
 
   const isLoggedIn = !!user;
   const [clicked, setClicked] = useState(false);
+  const isFirstUser = user?.loginCount === 1;
 
   useEffect(() => {
     if (clicked && isLoggedIn) {
-      flow.push('MyPageTab', {});
+      if (!isFirstUser) {
+        flow.push('MyPageTab', {});
+      }
+      if (isFirstUser) {
+        flow.push('JoinFormScreen', {});
+      }
       loginBottomSheet.close();
       setClicked(false);
     }
-  }, [clicked, isLoggedIn, flow, loginBottomSheet]);
+  }, [clicked, isLoggedIn, flow, loginBottomSheet, isFirstUser]);
 
   const handleClick = (e: React.MouseEvent) => {
     if (isActive) e.preventDefault();

--- a/apps/user-front/src/libs/stackflow/index.ts
+++ b/apps/user-front/src/libs/stackflow/index.ts
@@ -6,6 +6,7 @@ import { basicRendererPlugin } from '@stackflow/plugin-renderer-basic';
 import { stackflow } from '@stackflow/react/future';
 
 import { BookmarkListScreen } from '@/screens/bookmarks/Bookmarks';
+import { JoinFormScreen } from '@/screens/join/JoinFormScreen';
 import { MyCouponListScreen } from '@/screens/my-coupons/MyCoupons';
 import { NotificationListScreen } from '@/screens/notifications/Notifications';
 import { ProfileModifyScreen } from '@/screens/profile/ProfileModify';
@@ -41,6 +42,7 @@ declare module '@stackflow/config' {
     ReservationDetailScreen: { reservationId: number };
     ProfileModifyScreen: object;
     ProfileUserInfoScreen: {
+      isUpdateMode: boolean;
       gender: string;
       nickname: string | null;
       description: string | null;
@@ -49,6 +51,7 @@ declare module '@stackflow/config' {
       imageFile: File | null;
     };
     ProfileCompleteScreen: { userName: string };
+    JoinFormScreen: object;
   }
 }
 
@@ -71,6 +74,7 @@ const config = defineConfig({
     { name: 'ProfileModifyScreen' },
     { name: 'ProfileUserInfoScreen' },
     { name: 'ProfileCompleteScreen' },
+    { name: 'JoinFormScreen' },
   ],
 
   transitionDuration: 350,
@@ -97,6 +101,7 @@ export const { Stack } = stackflow({
     ProfileModifyScreen,
     ProfileUserInfoScreen,
     ProfileCompleteScreen,
+    JoinFormScreen,
   },
   plugins: [
     basicRendererPlugin(),

--- a/apps/user-front/src/screens/join/JoinFormScreen.tsx
+++ b/apps/user-front/src/screens/join/JoinFormScreen.tsx
@@ -9,14 +9,14 @@ import { useFlow } from '@stackflow/react/future';
 import { ErrorBoundary, ErrorBoundaryFallbackProps } from '@suspensive/react';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 
-import { ProfileForm } from './components/ProfileForm';
+import { ProfileForm } from '../profile/components/ProfileForm';
 import { Screen } from '@/components/Layout/Screen';
 import { useAuth } from '@/components/Provider/AuthProvider';
 import { useUpdateUserInfo } from '@/hooks/auth/useUpdateUserInfo';
 import { useUpdateUserProfileImage } from '@/hooks/auth/useUpdateUserProfileImage';
 import { useUploadFile } from '@/hooks/file/useUploadFile';
 
-export const ProfileModifyScreen: ActivityComponentType<'ProfileModifyScreen'> = () => {
+export const JoinFormScreen: ActivityComponentType<'JoinFormScreen'> = () => {
   const flow = useFlow();
 
   const { user } = useAuth();
@@ -32,7 +32,7 @@ export const ProfileModifyScreen: ActivityComponentType<'ProfileModifyScreen'> =
     const isFirstProfile = user.nickname === null;
 
     if (isFirstProfile) {
-      flow.push('ProfileUserInfoScreen', { ...formData, isUpdateMode: true });
+      flow.push('ProfileUserInfoScreen', { ...formData, isUpdateMode: false });
       return;
     }
 
@@ -64,7 +64,7 @@ export const ProfileModifyScreen: ActivityComponentType<'ProfileModifyScreen'> =
 
       flow.pop();
     } catch (error) {
-      console.error('프로필 수정 실패:', error);
+      console.error('프로필 입력 실패:', error);
     }
   };
 
@@ -87,7 +87,7 @@ export const ProfileModifyScreen: ActivityComponentType<'ProfileModifyScreen'> =
               <ProfileForm
                 handleSubmit={handleFormSubmit}
                 editOriginValue={editOriginValue}
-                isUpdateMode={true}
+                isUpdateMode={false}
               />
             </Suspense>
           </ErrorBoundary>

--- a/apps/user-front/src/screens/profile-user-info/ProfileUserInfo.tsx
+++ b/apps/user-front/src/screens/profile-user-info/ProfileUserInfo.tsx
@@ -26,16 +26,12 @@ import { useUploadFile } from '@/hooks/file/useUploadFile';
 
 export const ProfileUserInfoScreen: ActivityComponentType<'ProfileUserInfoScreen'> = ({
   params,
-}: {
-  params: any; //TODO: 추후 타입 수정
-}) => {
+}: any) => {
   const flow = useFlow();
-
   const { user } = useAuth();
   if (!user) {
     throw new Error('로그인이 필요합니다.');
   }
-
   const { mutateAsync: updateUserInfo } = useUpdateUserInfo();
   const { mutateAsync: uploadImageFile } = useUploadFile();
   const { mutateAsync: updateUserProfileImage } = useUpdateUserProfileImage();
@@ -71,12 +67,10 @@ export const ProfileUserInfoScreen: ActivityComponentType<'ProfileUserInfoScreen
         }
       }
 
-      if (user.phoneNumber || user.name === null)
+      if (!params.isUpdateMode)
         return flow.push('ProfileCompleteScreen', { userName: formData.name || '' });
-
-      return flow.pop();
     } catch (error) {
-      console.error('프로필 수정 실패:', error);
+      console.error('내 정보 수정 실패:', error);
 
       if (isAxiosError<UpdateProfileErrorResponse>(error)) {
         if (error.response?.data.code === UpdateProfileErrorCode.PHONE_NUMBER_ALREADY_EXISTS) {
@@ -105,6 +99,7 @@ export const ProfileUserInfoScreen: ActivityComponentType<'ProfileUserInfoScreen
           <ErrorBoundary fallback={ProfileErrorFallback} onReset={reset}>
             <Suspense>
               <ProfileUserInfoForm
+                isUpdateMode={params.isUpdateMode}
                 handleSubmit={handleFormSubmit}
                 editOriginValue={editOriginValue}
               />

--- a/apps/user-front/src/screens/profile-user-info/components/ProfileUserInfoForm.tsx
+++ b/apps/user-front/src/screens/profile-user-info/components/ProfileUserInfoForm.tsx
@@ -36,6 +36,7 @@ const formSchema = z.object({
 
 type FormSchemaType = z.infer<typeof formSchema>;
 export interface ProfileFormProps {
+  isUpdateMode: boolean;
   editOriginValue: AuthUpdateUserBody;
   handleSubmit: (
     data: AuthUpdateUserBody & { imageFile?: File | null },
@@ -46,6 +47,7 @@ export interface ProfileFormProps {
 export const ProfileUserInfoForm = ({
   editOriginValue,
   handleSubmit,
+  isUpdateMode,
 }: PropsWithoutRef<ProfileFormProps>) => {
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
   const { user } = useAuth();
@@ -104,10 +106,7 @@ export const ProfileUserInfoForm = ({
 
   return (
     <div className='flex flex-col p-grid-margin min-h-screen'>
-      <Header
-        left={<Header.Back />}
-        title={`내 정보 ${user.name === null || user.phoneNumber === null ? '입력' : '수정'}`}
-      />
+      <Header left={<Header.Back />} title={`내 정보 ${isUpdateMode ? '수정' : '입력'}`} />
       <div className='flex flex-col mt-[60px]'>
         <p className='mt-8 body-1'>리워드, 웨이팅, 예약에 사용될</p>
         <p className='body-1'>정보를 알려주세요!</p>
@@ -170,7 +169,15 @@ export const ProfileUserInfoForm = ({
             />
           </div>
           <div>
-            {user.name === null || user.phoneNumber === null ? (
+            {isUpdateMode ? (
+              <Button
+                type='button'
+                disabled={!!errors.name || !!errors.phoneNumber}
+                onClick={handleSaveClick}
+              >
+                저장
+              </Button>
+            ) : (
               <div className='w-full flex flex-col justify-between items-center h-[88px]'>
                 <a onClick={() => flow.push('HomeTab', {})} className='text-gray-5 body-6'>
                   {`다음에 할게요  :)`}
@@ -183,14 +190,6 @@ export const ProfileUserInfoForm = ({
                   다음
                 </Button>
               </div>
-            ) : (
-              <Button
-                type='button'
-                disabled={!!errors.name || !!errors.phoneNumber}
-                onClick={handleSaveClick}
-              >
-                저장
-              </Button>
             )}
             <BottomSheet isOpen={isBottomSheetOpen} onOpenChange={setIsBottomSheetOpen}>
               <BottomSheet.Content>
@@ -203,7 +202,11 @@ export const ProfileUserInfoForm = ({
                     <span>
                       {errors.phoneNumber
                         ? errors.phoneNumber.message
-                        : user.phoneNumber && formatPhoneNumber(watch('phoneNumber') || '')}
+                        : watch('phoneNumber')
+                          ? formatPhoneNumber(watch('phoneNumber'))
+                          : user.phoneNumber
+                            ? formatPhoneNumber(user.phoneNumber)
+                            : null}
                     </span>
                   </BottomSheet.Description>
                 </BottomSheet.Header>

--- a/apps/user-front/src/screens/profile/components/ProfileForm.tsx
+++ b/apps/user-front/src/screens/profile/components/ProfileForm.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { ChangeEvent, PropsWithoutRef, useMemo, useState } from 'react';
+import { ChangeEvent, PropsWithoutRef, useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { AuthUpdateUserBody, AuthUpdateUserProfileImageBody } from '@repo/api/auth';
@@ -26,6 +26,7 @@ const formSchema = z.object({
 type FormSchemaType = z.infer<typeof formSchema>;
 
 export interface ProfileFormProps {
+  isUpdateMode: boolean;
   editOriginValue: AuthUpdateUserBody & AuthUpdateUserProfileImageBody;
   handleSubmit: (data: AuthUpdateUserBody & { imageFile: File | null }) => void;
 }
@@ -33,6 +34,7 @@ export interface ProfileFormProps {
 export const ProfileForm = ({
   editOriginValue,
   handleSubmit,
+  isUpdateMode,
 }: PropsWithoutRef<ProfileFormProps>) => {
   const { user } = useAuth();
   const flow = useFlow();
@@ -51,8 +53,6 @@ export const ProfileForm = ({
 
   const { data: nicknameCheckData, refetch: checkNickname } =
     useGetUserNicknameCheck(nicknameToCheck);
-
-  const isUpdateMode = useMemo(() => user.loginCount > 0 && !!user.phoneNumber, [user]);
 
   const maxLength = 150;
 
@@ -135,7 +135,7 @@ export const ProfileForm = ({
                         height={120}
                       />
                     ) : (
-                      <div className='bg-gray-2 flex justify-center items-center text-[#111111]/10'>
+                      <div className='size-[120px] bg-gray-2 flex justify-center items-center text-[#111111]/10'>
                         <FoodingIcon />
                       </div>
                     )}
@@ -262,6 +262,7 @@ export const ProfileForm = ({
                 onClick={() => {
                   const formValues = getValues();
                   flow.push('ProfileUserInfoScreen', {
+                    isUpdateMode: isUpdateMode,
                     nickname: formValues.nickname,
                     description: formValues.description,
                     imageFile: selectedFile,

--- a/apps/user-front/src/screens/settings/Settings.tsx
+++ b/apps/user-front/src/screens/settings/Settings.tsx
@@ -32,6 +32,7 @@ export const SettingScreen: ActivityComponentType<'SettingScreen'> = () => {
           <MenuItem
             onClick={() =>
               flow.push('ProfileUserInfoScreen', {
+                isUpdateMode: true,
                 gender: user?.gender || 'NONE',
                 nickname: user?.nickname || null,
                 description: user?.description || null,


### PR DESCRIPTION
<!-- 제목: [FE-00] 이슈 제목 -->

## 🎫 관련 티켓
<!-- [이슈 제목](노션 링크) -->
[[fix/FE-180]: 내정보 수정/입력 화면 수정](https://github.com/FORCU27/fooding-frontend/pull/147)
<br />

## 📝 요약(Summary)
- 이전 PR올렸던 내정보 수정 부분 다시 올렸습니다.
- 처음 로그인 시 -> 첫 화면이 유저정보 입력으로 이동
- 일반 로그인 시 -> 기존 페이지, 정보수정 클릭시 정보 수정으로 이동

<br />

## 🛠️ PR 유형
<!-- 해당 항목에 'x'를 입력하면 체크됩니다. -->
- [ ] 기능 추가
- [ ] 버그 수정
- [ ] UI 수정 (스타일, 레이아웃 등)
- [x] 리팩토링 (동작 변경 없음)
- [ ] 문서 또는 주석 수정
- [ ] 테스트 코드 추가/수정
- [ ] 기타 구조 변경 (폴더명, 빌드 설정 등)  
<br />

## 📸스크린샷 (Optional)

<br />

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<br />
