### PR TITLE
[FE-157] USER 스토어 상세 - 포인트샵 탭 구현

### DIFF
--- a/apps/user-front/src/hooks/store/useGetStoreRewardList.ts
+++ b/apps/user-front/src/hooks/store/useGetStoreRewardList.ts
@@ -1,0 +1,13 @@
+import { queryKeys } from '@repo/api/configs/query-keys';
+import { storeApi } from '@repo/api/user';
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+export const useGetStoreRewardList = (id: number) => {
+  return useSuspenseQuery({
+    queryKey: [queryKeys.user.store.rewardList, id],
+    queryFn: async () => {
+      const response = await storeApi.getStoreRewardList(id);
+      return response.data;
+    },
+  });
+};

--- a/apps/user-front/src/hooks/store/usePurchaseStoreReward.ts
+++ b/apps/user-front/src/hooks/store/usePurchaseStoreReward.ts
@@ -1,0 +1,16 @@
+import { queryKeys } from '@repo/api/configs/query-keys';
+import { storeApi } from '@repo/api/user';
+import { useQueryClient, useMutation } from '@tanstack/react-query';
+
+export const usePurchaseStoreReward = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ storeId, rewardId }: { storeId: number; rewardId: number }) =>
+      storeApi.purchaseStoreReward(storeId, rewardId),
+    mutationKey: [queryKeys.user.store.reward],
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [queryKeys.user.store.reward] });
+    },
+  });
+};

--- a/apps/user-front/src/screens/store-detail/StoreDetail.tsx
+++ b/apps/user-front/src/screens/store-detail/StoreDetail.tsx
@@ -18,6 +18,7 @@ import { Suspense } from '@suspensive/react';
 import { StoreDetailHomeTab } from './components/tabs/Home';
 import { StoreDetailReviewTab } from './components/tabs/ReviewDetail';
 import { StoreDetailPostListTab } from './components/tabs/StorePostList';
+import { StoreRewardListTab } from './components/tabs/StoreRewardList';
 import { useLoginBottomSheet } from '@/components/Auth/LoginBottomSheet';
 import { Carousel } from '@/components/Carousel';
 import { LoadingToggle } from '@/components/Devtool/LoadingToggle';
@@ -159,6 +160,7 @@ const StoreDetail = ({ storeId, showHeader, initialTab = 'home' }: StoreDetailPr
             <ChipTabs.Trigger value='menu'>메뉴</ChipTabs.Trigger>
             <ChipTabs.Trigger value='photo'>사진</ChipTabs.Trigger>
             <ChipTabs.Trigger value='review'>리뷰</ChipTabs.Trigger>
+            <ChipTabs.Trigger value='reward'>리워드</ChipTabs.Trigger>
             <ChipTabs.Trigger value='info'>매장정보</ChipTabs.Trigger>
           </ChipTabs.List>
           <Suspense>
@@ -170,6 +172,9 @@ const StoreDetail = ({ storeId, showHeader, initialTab = 'home' }: StoreDetailPr
             </ChipTabs.Content>
             <ChipTabs.Content value='review'>
               <StoreDetailReviewTab store={store} />
+            </ChipTabs.Content>
+            <ChipTabs.Content value='reward'>
+              <StoreRewardListTab storeId={storeId} />
             </ChipTabs.Content>
           </Suspense>
         </ChipTabs>

--- a/apps/user-front/src/screens/store-detail/components/tabs/StoreRewardList.tsx
+++ b/apps/user-front/src/screens/store-detail/components/tabs/StoreRewardList.tsx
@@ -1,0 +1,246 @@
+import Image from 'next/image';
+import { useState } from 'react';
+
+import { Reward } from '@repo/api/user';
+import { BottomSheet, Button, Checkbox, EmptyState } from '@repo/design-system/components/b2c';
+import { FoodingIcon, GiftIcon } from '@repo/design-system/icons';
+import { useFlow } from '@stackflow/react/future';
+
+import { Section } from '@/components/Layout/Section';
+import { useGetStoreDetail } from '@/hooks/store/useGetStoreDetail';
+import { useGetStoreRewardList } from '@/hooks/store/useGetStoreRewardList';
+import { usePurchaseStoreReward } from '@/hooks/store/usePurchaseStoreReward';
+
+type StoreRewardListTabProps = {
+  storeId: number;
+};
+
+export const StoreRewardListTab = ({ storeId }: StoreRewardListTabProps) => {
+  const { data: rewards } = useGetStoreRewardList(storeId);
+  const { data: store } = useGetStoreDetail(storeId);
+
+  if (!store || rewards.pointShopItems.length === 0) {
+    return <EmptyState className='mt-16 mb-30' title='등록된 리워드가 없어요.' />;
+  }
+
+  return (
+    <Section className='flex flex-col bg-gray-1 mt-[14px]'>
+      <div className='flex flex-col gap-5 py-4 mb-25'>
+        <div className='flex rounded-xl p-5 bg-white justify-between'>
+          <div className='flex gap-3 justify-center items-center'>
+            {store.images[0]?.imageUrl ? (
+              <Image src={store.images[0].imageUrl} width={40} height={40} alt='스토어 이미지' />
+            ) : (
+              <div className='flex justify-center items-center w-10 h-10 rounded-xl'>
+                <FoodingIcon className='text-gray-2' />
+              </div>
+            )}
+            <div>
+              <p className='subtitle-4'>{store.name}</p>
+              <p className='subtitle-6 text-gray-5'>{rewards.point} 포인트</p>
+            </div>
+          </div>
+          <Button variant='outlined' size='small'>
+            적립내역
+          </Button>
+        </div>
+        {rewards.pointShopItems.map((reward) => (
+          <StoreRewardItem
+            key={reward.id}
+            reward={reward}
+            userPoint={rewards.point}
+            storeId={store.id}
+          />
+        ))}
+      </div>
+    </Section>
+  );
+};
+
+type StoreRewardItemProps = {
+  reward: Reward;
+  storeId: number;
+  userPoint: number;
+};
+
+const StoreRewardItem = ({ reward, storeId, userPoint }: StoreRewardItemProps) => {
+  const flow = useFlow();
+  const { mutate } = usePurchaseStoreReward();
+  const { data: store } = useGetStoreDetail(storeId);
+
+  const [isCheck, setIsCheck] = useState(false);
+  const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
+  const [isConfirmBottomSheetOpen, setIsConfirmBottomSheetOpen] = useState(false);
+
+  const resultPoint = userPoint - reward.point;
+  const isNotEnough = resultPoint < 0;
+
+  const handlePurchaseClick = () => {
+    mutate(
+      { storeId, rewardId: reward.id },
+      { onSuccess: () => setIsConfirmBottomSheetOpen(true) },
+    );
+    setIsCheck(false);
+    setIsBottomSheetOpen(false);
+  };
+
+  const handleConfirmClick = () => {
+    setIsConfirmBottomSheetOpen(false);
+
+    flow.push('MyCouponListScreen', {});
+  };
+
+  return (
+    <div className='flex flex-col rounded-xl p-5 bg-white gap-3'>
+      <div className='flex gap-2'>
+        <div className='flex w-25 h-25 justify-center items-center rounded-xl'>
+          <GiftIcon className='text-gray-2 w-[60px] h-[60px]' />
+        </div>
+        <div className='flex flex-col gap-2'>
+          <div
+            className={`inline-flex w-fit px-2 py-1 body-7 rounded-sm ${
+              reward.quantity === null || reward.quantity > 0
+                ? 'text-info-blue bg-[rgba(0,128,248,0.1)]'
+                : 'text-error-red bg-[rgba(225,19,0,0.1)]'
+            }`}
+          >
+            {reward.quantity === null || reward.quantity > 0 ? '판매중' : '구매불가'}
+          </div>
+          <p className='subtitle-5'>{reward.name}</p>
+          <p className='body-8 text-gray-5'>
+            남은 수량: {reward.quantity === null ? '무제한' : reward.quantity}
+          </p>
+          <p className='subtitle-1'>{reward.point} P</p>
+        </div>
+      </div>
+      <Button variant='outlined' onClick={() => setIsBottomSheetOpen(true)}>
+        구매하기
+      </Button>
+
+      <BottomSheet isOpen={isBottomSheetOpen} onOpenChange={setIsBottomSheetOpen}>
+        <BottomSheet.Content>
+          <BottomSheet.Header>
+            <BottomSheet.Title className='headline-3'>쿠폰 구매</BottomSheet.Title>
+          </BottomSheet.Header>
+          <BottomSheet.Body>
+            <div className='flex items-center mb-6 gap-4'>
+              <div className='flex justify-center items-center'>
+                <GiftIcon className='text-gray-2 w-[60px] h-[60px]' />
+              </div>
+              <div>
+                <p className='subtitle-1'>{reward.name}</p>
+                <p className='body-6 text-gray-5'>
+                  남은 수량: {reward.quantity === null ? '무제한' : reward.quantity}
+                </p>
+              </div>
+            </div>
+            <div className='flex flex-col p-5 gap-3 bg-gray-1 rounded-xl'>
+              <div className='flex justify-between'>
+                <p className='body-6 text-gray-5'>보유 포인트</p>
+                <p className={`body-5 ${isNotEnough ? 'text-error-red' : ''}`}>{userPoint} P</p>
+              </div>
+              <div className='flex justify-between'>
+                <p className='body-6 text-gray-5'>차감 포인트</p>
+                <p className='body-5'>{reward.point} P</p>
+              </div>
+              <hr className='text-gray-3' />
+              <div className='flex justify-between'>
+                <p className='body-6 text-gray-5'>구매 후 잔여 포인트</p>
+                <p className={`body-5 ${isNotEnough ? 'text-error-red' : ''}`}>
+                  {resultPoint < 0 ? '포인트 부족' : `${resultPoint} P`}
+                </p>
+              </div>
+            </div>
+            <Checkbox.Label className='pt-5 px-2'>
+              <Checkbox checked={isCheck} onChange={setIsCheck} className='w-[25px] h-[25px]' />
+              <Checkbox.LabelText>
+                쿠폰 구매 시 취소가 불가능하오니 확인 후 사용해주세요!
+              </Checkbox.LabelText>
+            </Checkbox.Label>
+          </BottomSheet.Body>
+          <BottomSheet.Footer>
+            <div className='flex w-full gap-2 justify-center '>
+              <Button
+                onClick={() => setIsBottomSheetOpen(false)}
+                variant='outlined'
+                size='large'
+                className='w-[30%]'
+              >
+                취소
+              </Button>
+              <Button
+                onClick={handlePurchaseClick}
+                variant='primary'
+                size='large'
+                className='w-[70%]'
+                disabled={!isCheck || isNotEnough}
+              >
+                구매하기
+              </Button>
+            </div>
+          </BottomSheet.Footer>
+        </BottomSheet.Content>
+      </BottomSheet>
+
+      <BottomSheet isOpen={isConfirmBottomSheetOpen} onOpenChange={setIsConfirmBottomSheetOpen}>
+        <BottomSheet.Content>
+          <BottomSheet.Body>
+            <div className='flex flex-col justify-center items-center gap-6'>
+              <CircleCheckIcon />
+              <div className='flex flex-col headline-3'>쿠폰이 구매되었습니다!</div>
+            </div>
+
+            <div className='flex gap-3 mt-10 items-center p-5 bg-gray-1 border border-gray-2 rounded-xl'>
+              {store.images[0]?.imageUrl ? (
+                <Image src={store.images[0]?.imageUrl} width={60} height={60} alt='스토어 이미지' />
+              ) : (
+                <div className='flex justify-center items-center w-[60px] h-[60px] rounded-xl'>
+                  <GiftIcon className='text-gray-3' size={40} />
+                </div>
+              )}
+              <div>
+                <p className='subtitle-1'>{reward.name}</p>
+                <p className='body-6 text-gray-5'>{store.name}</p>
+              </div>
+            </div>
+          </BottomSheet.Body>
+          <BottomSheet.Footer>
+            <div className='flex w-full gap-2 justify-center '>
+              <Button
+                onClick={() => setIsConfirmBottomSheetOpen(false)}
+                variant='outlined'
+                size='large'
+                className='w-[30%]'
+              >
+                닫기
+              </Button>
+              <Button
+                onClick={handleConfirmClick}
+                variant='primary'
+                size='large'
+                className='w-[70%]'
+              >
+                쿠폰함으로
+              </Button>
+            </div>
+          </BottomSheet.Footer>
+        </BottomSheet.Content>
+      </BottomSheet>
+    </div>
+  );
+};
+
+const CircleCheckIcon = () => {
+  return (
+    <svg width='60' height='60' viewBox='0 0 60 60' fill='none' xmlns='http://www.w3.org/2000/svg'>
+      <path
+        d='M16 30L25 39L43 21'
+        stroke='#FF2B3D'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+      <circle cx='30' cy='30' r='29' stroke='#FF2B3D' strokeWidth='2' />
+    </svg>
+  );
+};

--- a/apps/user-front/src/tabs/my-page/MyPage.tsx
+++ b/apps/user-front/src/tabs/my-page/MyPage.tsx
@@ -21,6 +21,7 @@ import { Header } from '@/components/Layout/Header';
 import { Screen } from '@/components/Layout/Screen';
 import { useAuth } from '@/components/Provider/AuthProvider';
 import { StoresList } from '@/components/Store/StoresList';
+import { useGetInfiniteMyCouponList } from '@/hooks/coupon/useGetMyCouponList';
 import { useGetStoreList } from '@/hooks/store/useGetStoreList';
 import { useGetBookmarkList } from '@/hooks/user/useGetBookmarkList';
 import { BookmarkCard } from '@/screens/bookmarks/components/BookmarkCard';
@@ -67,6 +68,7 @@ const Content = () => {
     pageSize: 5,
   });
 
+  const { coupons } = useGetInfiniteMyCouponList({ used: false });
   return (
     <div className='w-full'>
       <div className='flex-col bg-white/80 pb-5 py-grid-margin'>
@@ -120,7 +122,7 @@ const Content = () => {
           >
             <TicketIcon />
             <p className='body-7 text-gray-5'>쿠폰</p>
-            <p className='subtitle-6'>3장</p>
+            <p className='subtitle-6'>{coupons && coupons.length}장</p>
           </div>
           <hr className='w-[2px] h-[81px] bg-gray-2 text-gray-2 mx-2' />
           <div className='flex flex-col justify-center items-center gap-1 cursor-pointer'>

--- a/packages/api/src/configs/queryKeys.ts
+++ b/packages/api/src/configs/queryKeys.ts
@@ -34,6 +34,8 @@ export const queryKeys = {
       operatingHours: 'userStoreOperatingHours',
       additionalInfo: 'userStoreAdditionalInfo',
       immediateEntryList: 'userStoreImmediateEntryList',
+      reward: 'userStoreReward',
+      rewardList: 'userStoreRewardList',
     },
     storePost: {
       list: 'userStorePostList',

--- a/packages/api/src/user/stores/index.ts
+++ b/packages/api/src/user/stores/index.ts
@@ -13,6 +13,7 @@ import {
   GetStoreOperatingHoursResponse,
   GetStoreReviewListRequest,
   GetStoreReviewListResponse,
+  GetStoreRewardListResponse,
 } from './type';
 import { api } from '../../shared';
 
@@ -53,5 +54,12 @@ export const storeApi = {
   getStoreImmediateEntryList: async (params: GetStoreListParams) => {
     const response = await api.get(`${ENDPOINT}/immediate-entry`, { params });
     return GetStoreListResponse.parse(response);
+  },
+  getStoreRewardList: async (storeId: number) => {
+    const response = await api.get(`${ENDPOINT}/${storeId}/rewards`);
+    return GetStoreRewardListResponse.parse(response);
+  },
+  purchaseStoreReward: async (storeId: number, id: number) => {
+    return await api.post(`${ENDPOINT}/${storeId}/rewards/${id}`);
   },
 };

--- a/packages/api/src/user/stores/type.ts
+++ b/packages/api/src/user/stores/type.ts
@@ -25,6 +25,9 @@ export const DAY_OF_WEEK = [
 ] as const;
 export type DayOfWeek = (typeof DAY_OF_WEEK)[number];
 
+export const PROVIDE_TYPES = ['ALL', 'REGULAR_CUSTOMER'] as const;
+export type ProvideType = (typeof PROVIDE_TYPES)[number];
+
 export type Store = z.infer<typeof Store>;
 export const Store = z.object({
   id: z.number(),
@@ -202,3 +205,24 @@ export type CreateStoreReviewBody = {
   service: number;
   imageUrls: string[];
 };
+
+export type Reward = z.infer<typeof Reward>;
+export const Reward = z.object({
+  id: z.number(),
+  name: z.string(),
+  point: z.number(),
+  provideType: z.enum(PROVIDE_TYPES),
+  conditions: z.string().nullable(),
+  quantity: z.number().nullable(),
+});
+
+export const RewardListResponse = <TListItem extends z.ZodType>(listItem: TListItem) =>
+  ApiResponse(
+    z.object({
+      point: z.number(),
+      pointShopItems: z.array(listItem),
+    }),
+  );
+
+export type GetStoreRewardListResponse = z.infer<typeof GetStoreRewardListResponse>;
+export const GetStoreRewardListResponse = RewardListResponse(Reward);


### PR DESCRIPTION
<!-- 제목: [FE-00] 이슈 제목 -->

## 🎫 관련 티켓
<!-- [이슈 제목](노션 링크) -->
[[FE-157] USER 스토어 상세 - 포인트샵 탭 구현
](https://www.notion.so/benkang/USER-22483feabad380449bd8c22cf622ca83?v=1ca83feabad3800fac18000cac82606b&source=copy_link)<br />

## 📝 요약(Summary)
- 가게 상세의 리워드 탭 추가했습니다.
- 마이페이지의 받은 쿠폰 수 연결했습니다.
<br />

## 🛠️ PR 유형
<!-- 해당 항목에 'x'를 입력하면 체크됩니다. -->
- [x] 기능 추가
- [ ] 버그 수정
- [x] UI 수정 (스타일, 레이아웃 등)
- [ ] 리팩토링 (동작 변경 없음)
- [ ] 문서 또는 주석 수정
- [ ] 테스트 코드 추가/수정
- [ ] 기타 구조 변경 (폴더명, 빌드 설정 등)  
<br />

## 📸스크린샷 (Optional)
<img width="378" height="815" alt="image" src="https://github.com/user-attachments/assets/08aea905-bfe9-4648-bcbf-1181a504f548" />
<img width="378" height="815" alt="image" src="https://github.com/user-attachments/assets/47e06379-0c56-4ab1-b268-12066bee68dd" />
<img width="378" height="815" alt="image" src="https://github.com/user-attachments/assets/3f7343e8-a5a2-4e66-a551-cc5892a02f51" />

<br />

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<br />
