### PR TITLE
[FE-197] USER 스토어 상세 - 길찾기

### DIFF
--- a/apps/user-front/src/screens/reservation-detail/ReservationDetail.tsx
+++ b/apps/user-front/src/screens/reservation-detail/ReservationDetail.tsx
@@ -58,6 +58,11 @@ const ReservationDetail = ({ reservationId }: StoreDetailProps) => {
     setIsAlertAccordionOpen((prev) => !prev);
   };
 
+  const getKakaoMapDirectionUrl = (latitude: number, longitude: number, name?: string) => {
+    const encodedName = encodeURIComponent(name ?? '목적지');
+    return `https://map.kakao.com/link/to/${encodedName},${latitude},${longitude}`;
+  };
+
   return (
     <div className='flex flex-col bg-gray-1'>
       <div className='flex flex-col p-5 bg-white/80'>
@@ -142,7 +147,18 @@ const ReservationDetail = ({ reservationId }: StoreDetailProps) => {
           </div>
         </div>
 
-        <Button variant='gray' size='large'>
+        <Button
+          variant='gray'
+          size='large'
+          onClick={() => {
+            const url = getKakaoMapDirectionUrl(
+              storeInfo.latitude,
+              storeInfo.longitude,
+              storeInfo.name,
+            );
+            window.open(url, '_blank');
+          }}
+        >
           <CompassIcon />
           <span className='ml-1'>길찾기</span>
         </Button>

--- a/apps/user-front/src/screens/store-detail/components/tabs/Home.tsx
+++ b/apps/user-front/src/screens/store-detail/components/tabs/Home.tsx
@@ -38,6 +38,11 @@ export const StoreDetailHomeTab = ({ store }: StoreDetailHomeTabProps) => {
   const { data: reviews } = useGetStoreReviewList(store.id);
   const { data: stores } = useGetStoreList({ sortType: 'RECENT' });
 
+  const getKakaoMapDirectionUrl = (latitude: number, longitude: number, name?: string) => {
+    const encodedName = encodeURIComponent(name ?? '목적지');
+    return `https://map.kakao.com/link/to/${encodedName},${latitude},${longitude}`;
+  };
+
   return (
     <div className='flex flex-col'>
       <Section className='mt-[10px] py-[20px] gap-[6px]'>
@@ -121,7 +126,15 @@ export const StoreDetailHomeTab = ({ store }: StoreDetailHomeTabProps) => {
             {store.direction}
           </span>
         </div>
-        <Button className='mt-5' variant='gray'>
+
+        <Button
+          className='mt-5'
+          variant='gray'
+          onClick={() => {
+            const url = getKakaoMapDirectionUrl(store.latitude, store.longitude, store.name);
+            window.open(url, '_blank');
+          }}
+        >
           <CompassIcon className='mr-1 size-[18px]' />
           길찾기
         </Button>

--- a/apps/user-front/src/screens/store-detail/components/tabs/ReviewDetail.tsx
+++ b/apps/user-front/src/screens/store-detail/components/tabs/ReviewDetail.tsx
@@ -46,7 +46,9 @@ export const StoreDetailReviewTab = ({ store }: StoreDetailReviewTabProps) => {
         <p className='body-4'>베스트순</p>
         <ChevronDownIcon size={16} className='stroke-gray-5 cursor-pointer' />
       </div>
-      {reviews?.list.length === 0 && <EmptyState className='mt-10' title='등록된 리뷰가 없어요!' />}
+      {reviews?.list.length === 0 && (
+        <EmptyState className='mt-10 mb-25' title='등록된 리뷰가 없어요!' />
+      )}
       {reviews && reviews?.list.length > 0 && (
         <ul className='flex flex-col mt-2 pb-24'>
           <ReviewsDetailList reviews={reviews?.list || []} />

--- a/apps/user-front/src/screens/waiting-detail/WaitingDetail.tsx
+++ b/apps/user-front/src/screens/waiting-detail/WaitingDetail.tsx
@@ -56,6 +56,11 @@ const WaitingDetail = ({ waitingId }: StoreDetailProps) => {
     setIsAlertAccordionOpen((prev) => !prev);
   };
 
+  const getKakaoMapDirectionUrl = (latitude: number, longitude: number, name?: string) => {
+    const encodedName = encodeURIComponent(name ?? '목적지');
+    return `https://map.kakao.com/link/to/${encodedName},${latitude},${longitude}`;
+  };
+
   return (
     <div className='flex flex-col bg-gray-1'>
       <div className='flex flex-col p-5 bg-white/80'>
@@ -172,7 +177,18 @@ const WaitingDetail = ({ waitingId }: StoreDetailProps) => {
           </div>
         </div>
 
-        <Button variant='gray' size='large'>
+        <Button
+          variant='gray'
+          size='large'
+          onClick={() => {
+            const url = getKakaoMapDirectionUrl(
+              storeInfo.latitude,
+              storeInfo.longitude,
+              storeInfo.name,
+            );
+            window.open(url, '_blank');
+          }}
+        >
           <CompassIcon />
           <span className='ml-1'>길찾기</span>
         </Button>


### PR DESCRIPTION
<!-- 제목: [FE-00] 이슈 제목 -->

## 🎫 관련 티켓
<!-- [이슈 제목](노션 링크) -->
[[FE-197] USER 스토어 상세 - 길찾기
](https://www.notion.so/benkang/USER-25283feabad380ca8598f40462851b02?v=1ca83feabad3800fac18000cac82606b&source=copy_link)<br />

## 📝 요약(Summary)
- 가게 상세, 웨이팅 등에서 길찾기 버튼을 누르면 카카오지도로 이동하고 목적지는 해당 가게로 가는 기능 추가했습니다.
- 카카오 지도에서는 새탭 열기로 길찾기 밖에 지원하지 않아 새탭으로 이동하도록 구현했습니다.

<br />

## 🛠️ PR 유형
<!-- 해당 항목에 'x'를 입력하면 체크됩니다. -->
- [x] 기능 추가
- [ ] 버그 수정
- [ ] UI 수정 (스타일, 레이아웃 등)
- [ ] 리팩토링 (동작 변경 없음)
- [ ] 문서 또는 주석 수정
- [ ] 테스트 코드 추가/수정
- [ ] 기타 구조 변경 (폴더명, 빌드 설정 등)  
<br />

## 📸스크린샷 (Optional)
<img width="694" height="499" alt="image" src="https://github.com/user-attachments/assets/4b045d66-1688-4474-ba73-fe24e2697067" />
<img width="843" height="503" alt="image" src="https://github.com/user-attachments/assets/12ba5639-ace4-4cd0-9920-20cbb2b50cf8" />

<br />

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<br />
