### PR TITLE
[USER] BottomSheet 스와이프 기능 추가, 인터페이스 변경

### DIFF
--- a/apps/user-front/src/components/Auth/LoginBottomSheet.tsx
+++ b/apps/user-front/src/components/Auth/LoginBottomSheet.tsx
@@ -15,7 +15,7 @@ type LoginBottomSheetProps = {
  */
 export const LoginBottomSheet = ({ isOpen, onOpenChange }: LoginBottomSheetProps) => {
   return (
-    <FullscreenBottomSheet isOpen={isOpen} onOpenChange={onOpenChange}>
+    <FullscreenBottomSheet open={isOpen} onOpenChange={onOpenChange}>
       <FullscreenBottomSheet.Content>
         <Login onSuccess={() => onOpenChange(false)} />
       </FullscreenBottomSheet.Content>

--- a/apps/user-front/src/components/ImageGallery.tsx
+++ b/apps/user-front/src/components/ImageGallery.tsx
@@ -21,7 +21,7 @@ export const ImageGallery = ({
   initialPage,
 }: ImageGalleryProps) => {
   return (
-    <FullscreenBottomSheet isOpen={isOpen} onOpenChange={(isOpen) => isOpen === false && onClose()}>
+    <FullscreenBottomSheet open={isOpen} onOpenChange={(isOpen) => isOpen === false && onClose()}>
       <FullscreenBottomSheet.Content className='bg-black' hideCloseButton>
         <Carousel initialPage={initialPage}>
           <div className='flex h-[60px] items-center text-white justify-between'>

--- a/apps/user-front/src/components/RegionMultiSelectBottomSheet.tsx
+++ b/apps/user-front/src/components/RegionMultiSelectBottomSheet.tsx
@@ -25,7 +25,7 @@ const RegionMultiSelectBottomSheet = (props: RegionMultiSelectBottomSheetProps) 
   const { isOpen, onOpenChange, trigger } = props;
 
   return (
-    <BottomSheet isOpen={isOpen} onOpenChange={onOpenChange}>
+    <BottomSheet open={isOpen} onOpenChange={onOpenChange}>
       {trigger && <BottomSheet.Trigger asChild>{trigger}</BottomSheet.Trigger>}
       <BottomSheet.Content>
         <Content {...props} />

--- a/apps/user-front/src/components/Store/ReviewDetailCard.tsx
+++ b/apps/user-front/src/components/Store/ReviewDetailCard.tsx
@@ -96,7 +96,7 @@ export const ReviewDetailCard = ({ review, store }: ReviewCardProps) => {
         </button>
       </div>
 
-      <BottomSheet isOpen={isBottomSheetOpen} onOpenChange={setIsBottomSheetOpen}>
+      <BottomSheet open={isBottomSheetOpen} onOpenChange={setIsBottomSheetOpen}>
         <BottomSheet.Content>
           <BottomSheet.Header>
             <BottomSheet.Title className='headline-3'>리뷰관리</BottomSheet.Title>
@@ -126,7 +126,7 @@ export const ReviewDetailCard = ({ review, store }: ReviewCardProps) => {
                     삭제
                   </button>
 
-                  <Dialog isOpen={isDialogOpen}>
+                  <Dialog open={isDialogOpen}>
                     <Dialog.Content className='p-5'>
                       <Dialog.Title className='text-center'>리뷰 삭제</Dialog.Title>
                       <Dialog.Body className='flex flex-col text-center py-10'>

--- a/apps/user-front/src/screens/my-coupons/MyCoupons.tsx
+++ b/apps/user-front/src/screens/my-coupons/MyCoupons.tsx
@@ -245,7 +245,7 @@ const ApplyCouponDialog = ({ isOpen, onOpenChange, coupon }: ApplyCouponDialogPr
   };
 
   return (
-    <Dialog isOpen={isOpen} onOpenChange={onOpenChange}>
+    <Dialog open={isOpen} onOpenChange={onOpenChange}>
       <Dialog.Content className='w-[400px]'>
         <>
           {!success && (

--- a/apps/user-front/src/screens/profile-user-info/components/ProfileUserInfoForm.tsx
+++ b/apps/user-front/src/screens/profile-user-info/components/ProfileUserInfoForm.tsx
@@ -203,7 +203,7 @@ export const ProfileUserInfoForm = ({
                 </Button>
               </div>
             )}
-            <BottomSheet isOpen={isBottomSheetOpen} onOpenChange={setIsBottomSheetOpen}>
+            <BottomSheet open={isBottomSheetOpen} onOpenChange={setIsBottomSheetOpen}>
               <BottomSheet.Content>
                 <BottomSheet.Header>
                   <BottomSheet.Title className='headline-3'>

--- a/apps/user-front/src/screens/reports/components/ReviewReportForm.tsx
+++ b/apps/user-front/src/screens/reports/components/ReviewReportForm.tsx
@@ -123,7 +123,7 @@ export const ReviewReportForm = ({
           신고하기
         </Button>
 
-        <Dialog isOpen={isOpen}>
+        <Dialog open={isOpen}>
           <Dialog.Content className='p-5'>
             <Dialog.Title className='text-center'>리뷰 신고</Dialog.Title>
             <Dialog.Body className='flex flex-col text-center py-10'>

--- a/apps/user-front/src/screens/store-detail/StoreDetail.tsx
+++ b/apps/user-front/src/screens/store-detail/StoreDetail.tsx
@@ -222,7 +222,7 @@ const StoreDetail = ({ storeId, showHeader, initialTab = 'home' }: StoreDetailPr
           {store.isFinished ? '영업 종료' : '줄서기'}
         </Button>
       </div>
-      <BottomSheet isOpen={isBottomSheetOpen} onOpenChange={setIsBottomSheetOpen}>
+      <BottomSheet open={isBottomSheetOpen} onOpenChange={setIsBottomSheetOpen}>
         <BottomSheet.Content>
           <BottomSheet.Header>
             <BottomSheet.Title className='headline-3'>방문 인원을 선택하세요</BottomSheet.Title>

--- a/apps/user-front/src/screens/store-detail/components/tabs/StoreRewardList.tsx
+++ b/apps/user-front/src/screens/store-detail/components/tabs/StoreRewardList.tsx
@@ -150,7 +150,7 @@ const StoreRewardItem = ({ reward, storeId, userPoint }: StoreRewardItemProps) =
         구매하기
       </Button>
 
-      <BottomSheet isOpen={isBottomSheetOpen} onOpenChange={setIsBottomSheetOpen}>
+      <BottomSheet open={isBottomSheetOpen} onOpenChange={setIsBottomSheetOpen}>
         <BottomSheet.Content>
           <BottomSheet.Header>
             <BottomSheet.Title className='headline-3'>쿠폰 구매</BottomSheet.Title>
@@ -215,7 +215,7 @@ const StoreRewardItem = ({ reward, storeId, userPoint }: StoreRewardItemProps) =
         </BottomSheet.Content>
       </BottomSheet>
 
-      <BottomSheet isOpen={isConfirmBottomSheetOpen} onOpenChange={setIsConfirmBottomSheetOpen}>
+      <BottomSheet open={isConfirmBottomSheetOpen} onOpenChange={setIsConfirmBottomSheetOpen}>
         <BottomSheet.Content>
           <BottomSheet.Body>
             <div className='flex flex-col justify-center items-center gap-6'>

--- a/packages/design-system/package.json
+++ b/packages/design-system/package.json
@@ -41,7 +41,8 @@
     "react-dom": "^19.1.0",
     "react-hot-toast": "^2.6.0",
     "tailwind-merge": "^3.2.0",
-    "tailwind-variants": "^1.0.0"
+    "tailwind-variants": "^1.0.0",
+    "vaul": "^1.1.2"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^4.0.0",

--- a/packages/design-system/src/components/b2c/BottomSheet.stories.tsx
+++ b/packages/design-system/src/components/b2c/BottomSheet.stories.tsx
@@ -42,7 +42,7 @@ export const Controlled: Story = {
     const [isOpen, setIsOpen] = useState(false);
 
     return (
-      <BottomSheet isOpen={isOpen} onOpenChange={setIsOpen}>
+      <BottomSheet open={isOpen} onOpenChange={setIsOpen}>
         <BottomSheet.Trigger asChild>
           <Button size='small'>열기</Button>
         </BottomSheet.Trigger>

--- a/packages/design-system/src/components/b2c/BottomSheet.tsx
+++ b/packages/design-system/src/components/b2c/BottomSheet.tsx
@@ -2,28 +2,22 @@
 
 import { useId } from 'react';
 
-import { Dialog as DialogPrimitives } from 'radix-ui';
+import { Drawer } from 'vaul';
 
 import { CheckIcon } from '../../icons';
 import { cn, createContext } from '../../utils';
 
-type BottomSheetProps = Omit<DialogPrimitives.DialogProps, 'open'> & {
-  isOpen?: boolean;
+type BottomSheetProps = React.ComponentPropsWithRef<typeof Drawer.Root>;
+
+const BottomSheet = ({ children, ...props }: BottomSheetProps) => {
+  return <Drawer.Root {...props}>{children}</Drawer.Root>;
 };
 
-const BottomSheet = ({ children, isOpen, ...props }: BottomSheetProps) => {
-  return (
-    <DialogPrimitives.Root open={isOpen} {...props}>
-      {children}
-    </DialogPrimitives.Root>
-  );
-};
-
-type BottomSheetOverlayProps = React.ComponentPropsWithRef<typeof DialogPrimitives.Overlay>;
+type BottomSheetOverlayProps = React.ComponentPropsWithRef<typeof Drawer.Overlay>;
 
 const BottomSheetOverlay = ({ className, children, ...props }: BottomSheetOverlayProps) => {
   return (
-    <DialogPrimitives.Overlay
+    <Drawer.Overlay
       className={cn(
         'fixed inset-0 z-50 bg-black/50',
         'data-[state=open]:animate-in data-[state=open]:fade-in',
@@ -33,26 +27,26 @@ const BottomSheetOverlay = ({ className, children, ...props }: BottomSheetOverla
       {...props}
     >
       {children}
-    </DialogPrimitives.Overlay>
+    </Drawer.Overlay>
   );
 };
 
-type DialogContentProps = React.ComponentPropsWithRef<typeof DialogPrimitives.Content>;
+type DialogContentProps = React.ComponentPropsWithRef<typeof Drawer.Content>;
 
 const BottomSheetContent = ({ className, children, ...props }: DialogContentProps) => {
   const titleId = useId();
   const descriptionId = useId();
 
   return (
-    <DialogPrimitives.Portal>
+    <Drawer.Portal>
       <BottomSheetOverlay />
-      <DialogPrimitives.Title aria-labelledby={titleId} className='sr-only'>
+      <Drawer.Title aria-labelledby={titleId} className='sr-only'>
         Title
-      </DialogPrimitives.Title>
-      <DialogPrimitives.Description aria-describedby={descriptionId} className='sr-only'>
+      </Drawer.Title>
+      <Drawer.Description aria-describedby={descriptionId} className='sr-only'>
         Description
-      </DialogPrimitives.Description>
-      <DialogPrimitives.Content
+      </Drawer.Description>
+      <Drawer.Content
         className={cn(
           'fixed bottom-0 left-0 right-0 z-50',
           'flex w-full flex-col max-h-[calc(100%-20px)]',
@@ -68,8 +62,8 @@ const BottomSheetContent = ({ className, children, ...props }: DialogContentProp
           <span className='w-[40px] h-[4px] bg-[#D9D9D9] rounded-full' />
         </div>
         {children}
-      </DialogPrimitives.Content>
-    </DialogPrimitives.Portal>
+      </Drawer.Content>
+    </Drawer.Portal>
   );
 };
 
@@ -103,13 +97,13 @@ const BottomSheetFooter = ({ className, children, ...props }: BottomSheetFooterP
   );
 };
 
-type BottomSheetTriggerProps = React.ComponentPropsWithRef<typeof DialogPrimitives.Trigger>;
+type BottomSheetTriggerProps = React.ComponentPropsWithRef<typeof Drawer.Trigger>;
 
 const BottomSheetTrigger = ({ children, ...props }: BottomSheetTriggerProps) => {
   return (
-    <DialogPrimitives.Trigger aria-controls={undefined} {...props}>
+    <Drawer.Trigger aria-controls={undefined} {...props}>
       {children}
-    </DialogPrimitives.Trigger>
+    </Drawer.Trigger>
   );
 };
 
@@ -142,7 +136,7 @@ const BottomSheetSelectGroup = ({
   );
 };
 
-type BottomSheetSelectItemProps = React.ComponentPropsWithRef<typeof DialogPrimitives.Close> & {
+type BottomSheetSelectItemProps = React.ComponentPropsWithRef<typeof Drawer.Close> & {
   value: string;
 };
 
@@ -158,7 +152,7 @@ const BottomSheetSelectItem = ({
 
   return (
     <li className='flex'>
-      <DialogPrimitives.Close
+      <Drawer.Close
         className={cn(
           'text-gray-5 h-[60px] -mx-5 flex flex-1 items-center justify-between text-start text-base',
           'active:bg-gray-1 px-5',
@@ -170,15 +164,15 @@ const BottomSheetSelectItem = ({
       >
         {children}
         {isSelected && <CheckIcon className='text-primary-pink size-6' />}
-      </DialogPrimitives.Close>
+      </Drawer.Close>
     </li>
   );
 };
 
 BottomSheet.Trigger = BottomSheetTrigger;
-BottomSheet.Close = DialogPrimitives.Close;
-BottomSheet.Title = DialogPrimitives.Title;
-BottomSheet.Description = DialogPrimitives.Description;
+BottomSheet.Close = Drawer.Close;
+BottomSheet.Title = Drawer.Title;
+BottomSheet.Description = Drawer.Description;
 BottomSheet.Content = BottomSheetContent;
 BottomSheet.Header = BottomSheetHeader;
 BottomSheet.Body = BottomSheetBody;

--- a/packages/design-system/src/components/b2c/BottomSheetSelect.tsx
+++ b/packages/design-system/src/components/b2c/BottomSheetSelect.tsx
@@ -46,7 +46,7 @@ export const BottomSheetSelect = <TValue extends string>({
         <ChevronDownIcon className='text-gray-5 size-5' />
       </button>
 
-      <BottomSheet isOpen={isOpen} onOpenChange={setIsOpen}>
+      <BottomSheet open={isOpen} onOpenChange={setIsOpen}>
         <BottomSheet.Content aria-labelledby={titleId}>
           <BottomSheet.Header>
             <BottomSheet.Title id={titleId} className='font-bold text-[24px]'>

--- a/packages/design-system/src/components/b2c/Dialog.stories.tsx
+++ b/packages/design-system/src/components/b2c/Dialog.stories.tsx
@@ -2,6 +2,7 @@ import type { StoryObj } from '@storybook/react';
 
 import { Button } from './Button';
 import { Dialog } from './Dialog';
+import { useState } from 'react';
 
 const meta = {
   title: 'components/b2c/Dialog',
@@ -18,6 +19,35 @@ export const Default: Story = {
   render: () => {
     return (
       <Dialog>
+        <Dialog.Trigger asChild>
+          <Button size='small'>열기</Button>
+        </Dialog.Trigger>
+        <Dialog.Content className='w-[320px]'>
+          <Dialog.Header>
+            <Dialog.Title>모달 제목</Dialog.Title>
+            <Dialog.Description>모달 설명</Dialog.Description>
+          </Dialog.Header>
+          <Dialog.Body>모달 내용</Dialog.Body>
+          <Dialog.Footer className='gap-3'>
+            <Dialog.Close asChild>
+              <Button variant='outlined'>취소</Button>
+            </Dialog.Close>
+            <Dialog.Close asChild>
+              <Button>추가하기</Button>
+            </Dialog.Close>
+          </Dialog.Footer>
+        </Dialog.Content>
+      </Dialog>
+    );
+  },
+};
+
+export const Controlled: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
         <Dialog.Trigger asChild>
           <Button size='small'>열기</Button>
         </Dialog.Trigger>

--- a/packages/design-system/src/components/b2c/Dialog.tsx
+++ b/packages/design-system/src/components/b2c/Dialog.tsx
@@ -4,16 +4,10 @@ import { Dialog as DialogPrimitives } from 'radix-ui';
 
 import { cn } from '../../utils';
 
-type DialogProps = Omit<DialogPrimitives.DialogProps, 'open'> & {
-  isOpen?: boolean;
-};
+type DialogProps = DialogPrimitives.DialogProps;
 
-const Dialog = ({ children, isOpen, ...props }: DialogProps) => {
-  return (
-    <DialogPrimitives.Root open={isOpen} {...props}>
-      {children}
-    </DialogPrimitives.Root>
-  );
+const Dialog = ({ children, ...props }: DialogProps) => {
+  return <DialogPrimitives.Root {...props}>{children}</DialogPrimitives.Root>;
 };
 
 type DialogOverlayProps = React.ComponentPropsWithRef<typeof DialogPrimitives.Overlay>;

--- a/packages/design-system/src/components/b2c/FullscreenBottomSheet.stories.tsx
+++ b/packages/design-system/src/components/b2c/FullscreenBottomSheet.stories.tsx
@@ -2,6 +2,7 @@ import type { StoryObj } from '@storybook/react';
 
 import { FullscreenBottomSheet } from './FullscreenBottomSheet';
 import { Button } from './Button';
+import { useState } from 'react';
 
 const meta = {
   title: 'components/b2c/FullscreenBottomSheet',
@@ -18,6 +19,23 @@ export const Default: Story = {
   render: () => {
     return (
       <FullscreenBottomSheet>
+        <FullscreenBottomSheet.Trigger asChild>
+          <Button size='small'>열기</Button>
+        </FullscreenBottomSheet.Trigger>
+        <FullscreenBottomSheet.Content>
+          <div className='flex justify-center items-center flex-1'>전체화면 바텀시트</div>
+        </FullscreenBottomSheet.Content>
+      </FullscreenBottomSheet>
+    );
+  },
+};
+
+export const Controlled: Story = {
+  render: () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    return (
+      <FullscreenBottomSheet open={isOpen} onOpenChange={setIsOpen}>
         <FullscreenBottomSheet.Trigger asChild>
           <Button size='small'>열기</Button>
         </FullscreenBottomSheet.Trigger>

--- a/packages/design-system/src/components/b2c/FullscreenBottomSheet.tsx
+++ b/packages/design-system/src/components/b2c/FullscreenBottomSheet.tsx
@@ -5,10 +5,9 @@ import { Dialog as DialogPrimitives } from 'radix-ui';
 import { CloseIcon } from '../../icons';
 import { cn } from '../../utils';
 
-type FullscreenBottomSheetProps = Omit<DialogPrimitives.DialogProps, 'open'> & {
+type FullscreenBottomSheetProps = DialogPrimitives.DialogProps & {
   title?: string;
   description?: string;
-  isOpen?: boolean;
 };
 
 const DEFAULT_TITLE = '전체화면 바텀시트';
@@ -18,11 +17,10 @@ const FullscreenBottomSheet = ({
   children,
   title = DEFAULT_TITLE,
   description = DEFAULT_DESCRIPTION,
-  isOpen,
   ...props
 }: FullscreenBottomSheetProps) => {
   return (
-    <DialogPrimitives.Root open={isOpen} {...props}>
+    <DialogPrimitives.Root {...props}>
       <DialogPrimitives.Title className='sr-only'>{title}</DialogPrimitives.Title>
       <DialogPrimitives.Description className='sr-only'>{description}</DialogPrimitives.Description>
       {children}

--- a/packages/typescript-config/base.json
+++ b/packages/typescript-config/base.json
@@ -1,8 +1,6 @@
 {
   "$schema": "https://json.schemastore.org/tsconfig",
   "compilerOptions": {
-    "declaration": true,
-    "declarationMap": true,
     "esModuleInterop": true,
     "incremental": false,
     "isolatedModules": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -3278,6 +3278,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/primitive@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@radix-ui/primitive@npm:1.1.3"
+  checksum: 10/ee27abbff0d6d305816e9314655eb35e72478ba47416bc9d5cb0581728be35e3408cfc0748313837561d635f0cb7dfaae26e61831f0e16c0fd7d669a612f2cb0
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-accessible-icon@npm:1.1.7":
   version: 1.1.7
   resolution: "@radix-ui/react-accessible-icon@npm:1.1.7"
@@ -3565,6 +3572,38 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@radix-ui/react-dialog@npm:^1.1.1":
+  version: 1.1.15
+  resolution: "@radix-ui/react-dialog@npm:1.1.15"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.3"
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-context": "npm:1.1.2"
+    "@radix-ui/react-dismissable-layer": "npm:1.1.11"
+    "@radix-ui/react-focus-guards": "npm:1.1.3"
+    "@radix-ui/react-focus-scope": "npm:1.1.7"
+    "@radix-ui/react-id": "npm:1.1.1"
+    "@radix-ui/react-portal": "npm:1.1.9"
+    "@radix-ui/react-presence": "npm:1.1.5"
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-slot": "npm:1.2.3"
+    "@radix-ui/react-use-controllable-state": "npm:1.2.2"
+    aria-hidden: "npm:^1.2.4"
+    react-remove-scroll: "npm:^2.6.3"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/90ad9ea36d927a05bcc2701b471c2965f6d5d4f446511cd471e62235fc674186997dea081f52e18cb17a1e593828d94da3848e68864fa3acebe29df9b068b240
+  languageName: node
+  linkType: hard
+
 "@radix-ui/react-direction@npm:1.1.1":
   version: 1.1.1
   resolution: "@radix-ui/react-direction@npm:1.1.1"
@@ -3598,6 +3637,29 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10/e08733ee345521a09100f922191302960d87a723d3bebb804f5659ff37f2fae57e335b2debad5ac17cb929be6b1fa8bc092c016723665ea8c90f7cf396c92d3b
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-dismissable-layer@npm:1.1.11":
+  version: 1.1.11
+  resolution: "@radix-ui/react-dismissable-layer@npm:1.1.11"
+  dependencies:
+    "@radix-ui/primitive": "npm:1.1.3"
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-primitive": "npm:2.1.3"
+    "@radix-ui/react-use-callback-ref": "npm:1.1.1"
+    "@radix-ui/react-use-escape-keydown": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/c20772588423379dee47fbe1d45c238c45a3bbe612eaf64a86576bf81821975e256d92ac71f9151e91b94a73068656143a11da9a3e77de7564d2a9926468e37a
   languageName: node
   linkType: hard
 
@@ -3636,6 +3698,19 @@ __metadata:
     "@types/react":
       optional: true
   checksum: 10/618658e2b98575198b94ccfdd27f41beb37f83721c9a04617e848afbc47461124ae008d703d713b9644771d96d4852e49de322cf4be3b5f10a4f94d200db5248
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-focus-guards@npm:1.1.3":
+  version: 1.1.3
+  resolution: "@radix-ui/react-focus-guards@npm:1.1.3"
+  peerDependencies:
+    "@types/react": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+  checksum: 10/b57878f6cf0ebc3e8d7c5c6bbaad44598daac19c921551ca541c104201048a9a902f3d69196e7a09995fd46e998c309aab64dc30fa184b3609d67d187a6a9c24
   languageName: node
   linkType: hard
 
@@ -3995,6 +4070,26 @@ __metadata:
     "@types/react-dom":
       optional: true
   checksum: 10/ba01f385f6beedba7bf50ffd4aca8091554a67aee2b7252605876136155ceb2fcf1b627dccaf2e49032231eda271fe0e8915040729da9d1f95d08b854d815305
+  languageName: node
+  linkType: hard
+
+"@radix-ui/react-presence@npm:1.1.5":
+  version: 1.1.5
+  resolution: "@radix-ui/react-presence@npm:1.1.5"
+  dependencies:
+    "@radix-ui/react-compose-refs": "npm:1.1.2"
+    "@radix-ui/react-use-layout-effect": "npm:1.1.1"
+  peerDependencies:
+    "@types/react": "*"
+    "@types/react-dom": "*"
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+  peerDependenciesMeta:
+    "@types/react":
+      optional: true
+    "@types/react-dom":
+      optional: true
+  checksum: 10/4cdb05844c18877efb4b9739b46b7e5850b81d7ede994e75b5d62e8153a43c6e16b3ff9e55ff716e20b74b99b9415a94e97fd636bcb8698d5bbf7ab7b8663f9b
   languageName: node
   linkType: hard
 
@@ -5415,6 +5510,7 @@ __metadata:
     tailwind-variants: "npm:^1.0.0"
     tailwindcss: "npm:^4.1.7"
     typescript: "npm:^5.8.2"
+    vaul: "npm:^1.1.2"
     vite: "npm:^6.3.5"
   languageName: unknown
   linkType: soft
@@ -17120,6 +17216,18 @@ __metadata:
   version: 1.1.2
   resolution: "vary@npm:1.1.2"
   checksum: 10/31389debef15a480849b8331b220782230b9815a8e0dbb7b9a8369559aed2e9a7800cd904d4371ea74f4c3527db456dc8e7ac5befce5f0d289014dbdf47b2242
+  languageName: node
+  linkType: hard
+
+"vaul@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "vaul@npm:1.1.2"
+  dependencies:
+    "@radix-ui/react-dialog": "npm:^1.1.1"
+  peerDependencies:
+    react: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+    react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0.0 || ^19.0.0-rc
+  checksum: 10/9d34f7f9aae1994450233f7803fcd47dca7680bc621ee24717b8e78b72fda9c5156e1ff2c8af6c2705993224fd8d3725ed89d84ba5bd1d411124dd91cde2b2e5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- 제목: [FE-00] 이슈 제목 -->

## 🎫 관련 티켓
<!-- [이슈 제목](노션 링크) -->
<br />

## 📝 요약(Summary)

- vaul 라이브러리를 사용하여 바텀시트를 스와이프로 닫을 수 있도록 기능 추가
- 다른 컴포넌트와의 일관성을 위해 `BottomSheet`, `Dialog`, `FullscreenDialog`, controlled 관련 props 수정 `isOpen` -> `open`
- tsconfig의 `declaration`, `declarationMap` 제거 (모노레포 관련 이슈)
```
The inferred type of X cannot be named without a reference to Y
```

<br />

## 🛠️ PR 유형
<!-- 해당 항목에 'x'를 입력하면 체크됩니다. -->
- [x] 기능 추가
- [ ] 버그 수정
- [ ] UI 수정 (스타일, 레이아웃 등)
- [x] 리팩토링 (동작 변경 없음)
- [ ] 문서 또는 주석 수정
- [ ] 테스트 코드 추가/수정
- [x] 기타 구조 변경 (폴더명, 빌드 설정 등)  
<br />

## 📸스크린샷 (Optional)

<br />

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<br />
