### PR TITLE
[USER] 바텀 탭 아이콘 변경

### DIFF
--- a/apps/user-front/src/components/AuthTab/PlanLink.tsx
+++ b/apps/user-front/src/components/AuthTab/PlanLink.tsx
@@ -1,6 +1,6 @@
 import { JSX, useEffect, useState } from 'react';
 
-import { UserIcon } from '@repo/design-system/icons';
+import { MenuIcon } from '@repo/design-system/icons';
 import { Link } from '@stackflow/link/future';
 import { useFlow } from '@stackflow/react/future';
 
@@ -48,7 +48,7 @@ export const PlanLink = ({ BottomTabItem, BottomTabLabel, isActive }: PlanLinkPr
         animate={false}
         onClick={handleClick}
       >
-        <UserIcon size={24} />
+        <MenuIcon size={24} />
         <BottomTabLabel>예약/웨이팅</BottomTabLabel>
       </Link>
     </BottomTabItem>

--- a/packages/design-system/src/icons/MenuIcon.tsx
+++ b/packages/design-system/src/icons/MenuIcon.tsx
@@ -1,0 +1,25 @@
+import { IconProps } from './type';
+
+const MenuIcon = ({ size = 24, color = 'currentColor', fill = 'none', ...props }: IconProps) => {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox='0 0 24 24'
+      color={color}
+      stroke='currentColor'
+      fill={fill}
+      xmlns='http://www.w3.org/2000/svg'
+      {...props}
+    >
+      <path
+        d='M21 12L9 12M21 6L9 6M21 18L9 18M5 12C5 12.5523 4.55228 13 4 13C3.44772 13 3 12.5523 3 12C3 11.4477 3.44772 11 4 11C4.55228 11 5 11.4477 5 12ZM5 6C5 6.55228 4.55228 7 4 7C3.44772 7 3 6.55228 3 6C3 5.44772 3.44772 5 4 5C4.55228 5 5 5.44772 5 6ZM5 18C5 18.5523 4.55228 19 4 19C3.44772 19 3 18.5523 3 18C3 17.4477 3.44772 17 4 17C4.55228 17 5 17.4477 5 18Z'
+        strokeWidth='2'
+        strokeLinecap='round'
+        strokeLinejoin='round'
+      />
+    </svg>
+  );
+};
+
+export default MenuIcon;

--- a/packages/design-system/src/icons/index.ts
+++ b/packages/design-system/src/icons/index.ts
@@ -37,3 +37,4 @@ export { default as CeoBellIcon } from './CeoBellIcon';
 export { default as KebabButton } from './KebabButton';
 export { default as PinIcon } from './PinIcon';
 export { default as PlayVideoIcon } from './PlayVideoIcon';
+export { default as MenuIcon } from './MenuIcon';


### PR DESCRIPTION
<!-- 제목: [FE-00] 이슈 제목 -->

## 🎫 관련 티켓
<!-- [이슈 제목](노션 링크) -->
<br />

## 📝 요약(Summary)

- 바텀 탭 예약/웨이팅 아이콘이 잘못 들어가있던 부분을 수정했습니다

<br />

## 🛠️ PR 유형
<!-- 해당 항목에 'x'를 입력하면 체크됩니다. -->
- [ ] 기능 추가
- [ ] 버그 수정
- [x] UI 수정 (스타일, 레이아웃 등)
- [ ] 리팩토링 (동작 변경 없음)
- [ ] 문서 또는 주석 수정
- [ ] 테스트 코드 추가/수정
- [ ] 기타 구조 변경 (폴더명, 빌드 설정 등)  
<br />

## 📸스크린샷 (Optional)

<img width="116" height="70" alt="스크린샷 2025-09-17 오후 12 03 14" src="https://github.com/user-attachments/assets/ab2783be-4826-4d70-a700-c9c4d01fb052" />


<br />

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<br />
