### PR TITLE
[USER] 홈, 가게 상세 UI 수정

### DIFF
--- a/apps/user-front/src/components/Layout/Divider.tsx
+++ b/apps/user-front/src/components/Layout/Divider.tsx
@@ -3,5 +3,5 @@ import { cn } from '@/utils/cn';
 type DividerProps = React.ComponentPropsWithRef<'div'>;
 
 export const Divider = ({ className, ...props }: DividerProps) => {
-  return <div className={cn('h-[10px] bg-gray-1 w-full', className)} {...props} />;
+  return <div className={cn('flex shrink-0 h-[10px] bg-gray-1 w-full', className)} {...props} />;
 };

--- a/apps/user-front/src/components/Store/ReviewsList.tsx
+++ b/apps/user-front/src/components/Store/ReviewsList.tsx
@@ -10,7 +10,7 @@ export const ReviewsList = ({ reviews }: ReviewsListProps) => {
   return (
     <>
       {reviews.map((review) => (
-        <li key={review.reviewId} className='flex py-grid-margin bg-white/80'>
+        <li key={review.reviewId} className='flex bg-white/80'>
           {<ReviewCard review={review} />}
         </li>
       ))}

--- a/apps/user-front/src/components/Store/StoreCard.tsx
+++ b/apps/user-front/src/components/Store/StoreCard.tsx
@@ -15,7 +15,7 @@ export const StoreCard = ({ store }: StoreCardProps) => {
     <li key={store.id} className='flex flex-col min-h-[240px] relative'>
       <div className='h-full w-[140px]'>
         <div
-          className='relative h-[140px] w-[140px] mb-2 rounded-xl overflow-hidden'
+          className='relative h-[140px] w-[140px] rounded-xl overflow-hidden'
           onClick={() => flow.push('StoreDetailScreen', { storeId: store.id })}
         >
           {store.mainImage !== null ? (
@@ -36,23 +36,19 @@ export const StoreCard = ({ store }: StoreCardProps) => {
             </div>
           )}
         </div>
-        <div>
-          <div className='flex p-1'>
-            <span className='break-words line-clamp-2 subtitle-5 w-[144px]'>{store.name}</span>
+        <span className='mt-3 line-clamp-2 subtitle-5 w-[144px]'>{store.name}멜멞</span>
+        <div className='mt-1 flex flex-col gap-1'>
+          <div className='subtitle-5 flex items-center gap-1 h-[17px]'>
+            <StarIcon size={18} fill='#FFD83D' color='#FFD83D' />
+            <span className='text-[#FFD83D] subtitle-6'>{store.averageRating}</span>
+            <span className='body-6 text-gray-5'>({store.reviewCount})</span>
           </div>
-          <div className='flex flex-col gap-1'>
-            <div className='subtitle-5 flex items-center gap-1 h-[17px]'>
-              <StarIcon size={18} fill='#FFD83D' color='#FFD83D' />
-              <span className='text-[#FFD83D] subtitle-6'>{store.averageRating}</span>
-              <span className='body-6 text-gray-5'>({store.reviewCount})</span>
-            </div>
-            <p className='body-8 text-gray-5'>
-              {/* {store.length >= 3 ? store.city.slice(0, 2) : store.city} •{' '} */}
-              {store.estimatedWaitingTimeMinutes
-                ? `예상 대기시간 ${store.estimatedWaitingTimeMinutes}분`
-                : '바로 입장가능'}
-            </p>
-          </div>
+          <p className='body-8 text-gray-5'>
+            {/* {store.length >= 3 ? store.city.slice(0, 2) : store.city} •{' '} */}
+            {store.estimatedWaitingTimeMinutes
+              ? `예상 대기시간 ${store.estimatedWaitingTimeMinutes}분`
+              : '바로 입장가능'}
+          </p>
         </div>
       </div>
     </li>

--- a/apps/user-front/src/components/Store/StoresList.tsx
+++ b/apps/user-front/src/components/Store/StoresList.tsx
@@ -3,24 +3,25 @@ import { EmptyState } from '@repo/design-system/components/b2c';
 import { ChevronRightIcon } from '@repo/design-system/icons';
 
 import { StoreCard } from './StoreCard';
+import { cn } from '@/utils/cn';
 
 interface StoresListProps {
+  className?: string;
   subtitle: string;
   onClickTotalBtn: () => void;
   stores: Store[];
 }
 
-export const StoresList = ({ subtitle, stores, onClickTotalBtn }: StoresListProps) => {
+export const StoresList = ({ className, subtitle, stores, onClickTotalBtn }: StoresListProps) => {
   const handleEmptyStoreList = (stores: Store[]) => {
     if (stores.length === 0) {
       return <EmptyState className='h-[240px]' title='해당하는 가게 목록이 없어요!' />;
     }
   };
   return (
-    <div className='flex flex-col py-grid-margin bg-white/80'>
+    <div className={cn('flex flex-col py-grid-margin bg-white/80', className)}>
       <div className='flex justify-between mb-4 px-grid-margin'>
         <div className='subtitle-3'>{subtitle}</div>
-
         {stores.length === 0 ? (
           <button
             className='flex justify-center items-center body-5 text-gray-3'
@@ -28,7 +29,7 @@ export const StoresList = ({ subtitle, stores, onClickTotalBtn }: StoresListProp
             disabled
           >
             <span>전체보기</span>
-            <ChevronRightIcon size={14} />
+            <ChevronRightIcon size={18} />
           </button>
         ) : (
           <button
@@ -36,7 +37,7 @@ export const StoresList = ({ subtitle, stores, onClickTotalBtn }: StoresListProp
             onClick={onClickTotalBtn}
           >
             <span>전체보기</span>
-            <ChevronRightIcon size={14} />
+            <ChevronRightIcon size={18} />
           </button>
         )}
       </div>

--- a/apps/user-front/src/screens/store-detail/StoreDetail.tsx
+++ b/apps/user-front/src/screens/store-detail/StoreDetail.tsx
@@ -1,8 +1,9 @@
 'use client';
 
 import Image from 'next/image';
-import { useEffect, useRef, useState } from 'react';
+import { useRef, useState } from 'react';
 
+import { STORE_CATEOGORY_LABELS } from '@repo/api/user';
 import {
   BottomSheet,
   Button,
@@ -32,6 +33,7 @@ import { useLoginBottomSheet } from '@/components/Auth/LoginBottomSheet';
 import { Carousel } from '@/components/Carousel';
 import { LoadingToggle } from '@/components/Devtool/LoadingToggle';
 import { DefaultErrorBoundary } from '@/components/Layout/DefaultErrorBoundary';
+import { Divider } from '@/components/Layout/Divider';
 import { Header } from '@/components/Layout/Header';
 import { Screen } from '@/components/Layout/Screen';
 import { Section } from '@/components/Layout/Section';
@@ -95,10 +97,6 @@ const StoreDetail = ({ storeId, showHeader, initialTab = 'home' }: StoreDetailPr
   const [isBookmarked, setIsBookmarked] = useState(store.isBookmarked);
   const [isBottomSheetOpen, setIsBottomSheetOpen] = useState(false);
 
-  useEffect(() => {
-    setIsBookmarked(store.isBookmarked);
-  }, [store.isBookmarked]);
-
   const handleBookmarkClick = (e: React.MouseEvent) => {
     if (!isLoggedIn && !isBookmarked) {
       e.preventDefault();
@@ -139,7 +137,7 @@ const StoreDetail = ({ storeId, showHeader, initialTab = 'home' }: StoreDetailPr
         <span className='flex items-center body-5 text-gray-5'>
           {store.address}
           <span className='mx-[6px] w-[1px] h-[12px] bg-[#76767630]' />
-          {store.category}
+          {STORE_CATEOGORY_LABELS[store.category]}
         </span>
         <h1 className='mt-[10px] headline-2 text-black' data-testid='store-name'>
           {store.name}
@@ -152,7 +150,8 @@ const StoreDetail = ({ storeId, showHeader, initialTab = 'home' }: StoreDetailPr
           <span className='ml-1 body-5 text-gray-5'>( 리뷰 {store.reviewCount}개 )</span>
         </div>
       </Section>
-      <Section className='mt-[10px] flex-row py-[20px] divide-x divide-gray-1'>
+      <Divider />
+      <Section className='flex-row py-[20px] divide-x divide-gray-1'>
         <div className='flex flex-col items-center flex-1'>
           <ColorFireIcon className='size-[50px]' />
           <span className='body-7 text-gray-5'>실시간</span>
@@ -169,9 +168,10 @@ const StoreDetail = ({ storeId, showHeader, initialTab = 'home' }: StoreDetailPr
           <span className='subtitle-6 text-black'>{store.estimatedWaitingTimeMinutes ?? 0}분</span>
         </div>
       </Section>
-      <Section className='mt-[10px] pt-[14px] pb-[100px]'>
+      <Section className='pb-[100px]'>
         <ChipTabs defaultValue={initialTab} scrollable>
-          <ChipTabs.List>
+          <Divider />
+          <ChipTabs.List className='py-[14px]'>
             <ChipTabs.Trigger value='home'>홈</ChipTabs.Trigger>
             <ChipTabs.Trigger value='news'>소식</ChipTabs.Trigger>
             <ChipTabs.Trigger value='menu'>메뉴</ChipTabs.Trigger>
@@ -180,6 +180,7 @@ const StoreDetail = ({ storeId, showHeader, initialTab = 'home' }: StoreDetailPr
             <ChipTabs.Trigger value='reward'>리워드</ChipTabs.Trigger>
             <ChipTabs.Trigger value='info'>매장정보</ChipTabs.Trigger>
           </ChipTabs.List>
+          <Divider />
           <Suspense>
             <ChipTabs.Content value='home'>
               <StoreDetailHomeTab store={store} />

--- a/apps/user-front/src/screens/store-detail/components/tabs/Home.tsx
+++ b/apps/user-front/src/screens/store-detail/components/tabs/Home.tsx
@@ -9,6 +9,7 @@ import {
 } from '@repo/design-system/icons';
 import { useFlow } from '@stackflow/react/future';
 
+import { Divider } from '@/components/Layout/Divider';
 import { Section } from '@/components/Layout/Section';
 import { MenuCard } from '@/components/Store/MenuCard';
 import { ReviewsList } from '@/components/Store/ReviewsList';
@@ -24,7 +25,6 @@ import { noop } from '@/utils/noop';
 
 // TODO: API 연동
 const mock = {
-  location: '제주 제주시 서해안로 654 바다풍경 정육식당',
   subwayLocation: '제주역에서 847m',
   subwayNumber: 6,
   operatingHours: '매일 10:40 - 21:50',
@@ -44,7 +44,7 @@ export const StoreDetailHomeTab = ({ store }: StoreDetailHomeTabProps) => {
 
   return (
     <div className='flex flex-col'>
-      <Section className='mt-[10px] py-[20px] gap-[6px]'>
+      <Section className='py-[20px] gap-[6px]'>
         <span className='body-6 flex items-center gap-[10px]'>
           <MarkPinIcon className='size-[18px] stroke-1' />
           {store.address}
@@ -63,7 +63,8 @@ export const StoreDetailHomeTab = ({ store }: StoreDetailHomeTabProps) => {
           {store.contactNumber}
         </span>
       </Section>
-      <Section className='mt-[10px] pb-8'>
+      <Divider />
+      <Section className='pb-8'>
         <Section.Header>
           <Section.Title>메뉴</Section.Title>
           <Section.Link>더보기</Section.Link>
@@ -82,7 +83,8 @@ export const StoreDetailHomeTab = ({ store }: StoreDetailHomeTabProps) => {
           </ul>
         )}
       </Section>
-      <Section className='mt-[10px]'>
+      <Divider />
+      <Section>
         <Section.Header>
           <Section.Title className='flex items-center gap-1'>
             리뷰
@@ -105,7 +107,8 @@ export const StoreDetailHomeTab = ({ store }: StoreDetailHomeTabProps) => {
           </ul>
         )}
       </Section>
-      <Section className='mt-[10px] pb-8'>
+      <Divider />
+      <Section className='pb-8'>
         <Section.Header>
           <Section.Title>매장 위치</Section.Title>
         </Section.Header>
@@ -129,13 +132,15 @@ export const StoreDetailHomeTab = ({ store }: StoreDetailHomeTabProps) => {
         </div>
         {store.latitude && store.longitude && (
           <PathfindingButton
+            className='mt-5'
             latitude={store.latitude}
             longitude={store.longitude}
             name={store.name}
           />
         )}
       </Section>
-      <div className='mt-[10px]'>
+      <Divider />
+      <div>
         {/* TODO: 다른사람이 함께 본 식당 목록 조회 기능 추가 */}
         <StoresList
           subtitle='다른사람이 함께 본 비슷한 식당'
@@ -154,14 +159,16 @@ export const StoreDetailHomeTab = ({ store }: StoreDetailHomeTabProps) => {
 };
 
 type PathfindingButtonProps = {
+  className?: string;
   latitude: number;
   longitude: number;
   name: string;
 };
 
-const PathfindingButton = ({ latitude, longitude, name }: PathfindingButtonProps) => {
+const PathfindingButton = ({ className, latitude, longitude, name }: PathfindingButtonProps) => {
   return (
     <Button
+      className={className}
       variant='gray'
       size='large'
       onClick={() => getKakaoMapDirectionUrl({ latitude, longitude, name })}

--- a/apps/user-front/src/screens/store-detail/components/tabs/Photo.tsx
+++ b/apps/user-front/src/screens/store-detail/components/tabs/Photo.tsx
@@ -1,4 +1,5 @@
 import { StoreInfo } from '@repo/api/user';
+import { EmptyState } from '@repo/design-system/components/b2c';
 import { overlay } from 'overlay-kit';
 import { Masonry } from 'react-plock';
 
@@ -27,6 +28,10 @@ export const StoreDetailPhotoTab = ({ store }: StoreDetailPhotoTabProps) => {
       />
     ));
   };
+
+  if (images.length === 0) {
+    return <EmptyState className='py-[100px]' title='올라온 사진이 없어요!' />;
+  }
 
   return (
     <Section className='flex flex-col'>

--- a/apps/user-front/src/screens/store-detail/components/tabs/StoreRewardList.tsx
+++ b/apps/user-front/src/screens/store-detail/components/tabs/StoreRewardList.tsx
@@ -23,7 +23,7 @@ export const StoreRewardListTab = ({ storeId }: StoreRewardListTabProps) => {
   const { data: store } = useGetStoreDetail(storeId);
 
   return (
-    <Section className='flex flex-col bg-gray-1 mt-[14px]'>
+    <Section className='flex flex-col bg-gray-1'>
       <div className='flex flex-col gap-5 py-4 mb-25'>
         <div className='flex rounded-xl p-5 bg-white justify-between'>
           <div className='flex gap-3 justify-center items-center'>

--- a/apps/user-front/src/tabs/home/Home.tsx
+++ b/apps/user-front/src/tabs/home/Home.tsx
@@ -13,6 +13,7 @@ import { HomeLoadingFallback } from './components/HomeLoadingFallback';
 import { MainStoreList } from './components/MainStoreList';
 import { LoadingToggle } from '@/components/Devtool/LoadingToggle';
 import BottomTab from '@/components/Layout/BottomTab';
+import { Divider } from '@/components/Layout/Divider';
 import { Screen } from '@/components/Layout/Screen';
 import { StoresList } from '@/components/Store/StoresList';
 import { useGetStoreImmediateEntryList } from '@/hooks/store/useGetStoreImmediateEntryList';
@@ -76,17 +77,24 @@ const ContentBody = () => {
       <Menubar />
       <div className='bg-white mb-3'>
         <Banner />
-        <div className='flex flex-col  py-grid-margin mb-3'>
+        <div className='flex flex-col py-grid-margin'>
           <CategoryTabs categories={STORE_CATEGORIES} />
           <MainStoreList stores={stores.list} />
         </div>
+        <Divider />
         <StoresList
           subtitle='푸딩에서 인기 많은 식당이에요'
           stores={popularStores.list}
           onClickTotalBtn={noop}
         />
-        <StoresList subtitle='새로 오픈했어요!' stores={stores.list} onClickTotalBtn={noop} />
         <StoresList
+          className='pt-0'
+          subtitle='새로 오픈했어요!'
+          stores={stores.list}
+          onClickTotalBtn={noop}
+        />
+        <StoresList
+          className='pt-0'
           subtitle='지금 바로 입장하실 수 있어요!'
           stores={immediateEntryStores.list}
           onClickTotalBtn={noop}

--- a/apps/user-front/src/tabs/home/components/CategoryTabs.tsx
+++ b/apps/user-front/src/tabs/home/components/CategoryTabs.tsx
@@ -6,7 +6,7 @@ interface CategoryTabsProps {
 }
 
 export const CategoryTabs = ({ categories }: CategoryTabsProps) => (
-  <div className='flex flex-col justify-between p-grid-margin gap-4'>
+  <div className='flex flex-col justify-between px-grid-margin pb-grid-margin gap-4'>
     <div className='subtitle-1'>오늘은 어디에서 식사할까요?</div>
     <ChipTabs defaultValue={`${1}`} scrollable>
       <ChipTabs.List>

--- a/apps/user-front/src/tabs/home/components/Header.tsx
+++ b/apps/user-front/src/tabs/home/components/Header.tsx
@@ -16,12 +16,12 @@ function Header() {
         {/* TODO: 레이아웃 시프트 생겨서 svg로 변경 필요 */}
         <Image src='/images/fooding_icon.png' width={48} height={48} alt='Fooding Icon' />
         <button
-          className='mr-3 relative w-full h-[44px] bg-gray-1 rounded-[8px] pl-11 pr-10 outline-none text-[14px] text-gray-5 flex items-center'
+          className='mr-3 relative w-full h-[44px] bg-gray-1 rounded-[8px] pl-4 outline-none text-[14px] text-gray-5 flex items-center'
           aria-label='검색'
           onClick={() => flow.push('SearchScreen', {})}
         >
-          <SearchIcon className='absolute top-1/2 left-3 -translate-y-1/2 text-gray-5' />
           지금 뜨는 이탈리안 레스토랑은?
+          <SearchIcon className='absolute top-1/2 right-3 -translate-y-1/2 text-gray-5' />
         </button>
         <div className='flex justify-between gap-4'>
           <AuthGuard>

--- a/apps/user-front/src/tabs/home/components/Menubar.tsx
+++ b/apps/user-front/src/tabs/home/components/Menubar.tsx
@@ -15,8 +15,8 @@ function Menubar() {
         onChange={setSelectedRegions}
         trigger={
           <button className='flex items-center gap-1'>
-            <MarkPinIcon />
-            <div className='flex p-1 gap-1 items-center'>
+            <MarkPinIcon className='size-5' />
+            <div className='flex gap-1 items-center'>
               <div className='subtitle-4'>
                 {isNonEmptyArray(selectedRegions) ? selectedRegions[0].name : '전체'}
               </div>


### PR DESCRIPTION
<!-- 제목: [FE-00] 이슈 제목 -->

## 🎫 관련 티켓
<!-- [이슈 제목](노션 링크) -->
<br />

## 📝 요약(Summary)

- 홈, 가게 상세 스크린 UI가 피그마와 맞지 않는 부분 수정 (섹션 간 구분선 위주)

<br />

## 🛠️ PR 유형
<!-- 해당 항목에 'x'를 입력하면 체크됩니다. -->
- [ ] 기능 추가
- [ ] 버그 수정
- [x] UI 수정 (스타일, 레이아웃 등)
- [ ] 리팩토링 (동작 변경 없음)
- [ ] 문서 또는 주석 수정
- [ ] 테스트 코드 추가/수정
- [ ] 기타 구조 변경 (폴더명, 빌드 설정 등)  
<br />

## 📸스크린샷 (Optional)

<img width="488" height="483" alt="Screenshot 2025-09-21 at 12 08 30 AM" src="https://github.com/user-attachments/assets/24e38f70-79ca-4b75-bb54-3079e91e22d7" />


<br />

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<br />
