### PR TITLE
[USER] 버그 수정 및 누락 기능 추가

### DIFF
--- a/apps/user-front/src/libs/stackflow/index.ts
+++ b/apps/user-front/src/libs/stackflow/index.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { Review, StoreInfo } from '@repo/api/user';
-import { defineConfig, RegisteredActivityName } from '@stackflow/config';
+import { defineConfig, Register } from '@stackflow/config';
 import { basicUIPlugin } from '@stackflow/plugin-basic-ui';
 import { basicRendererPlugin } from '@stackflow/plugin-renderer-basic';
 import { stackflow } from '@stackflow/react/future';
@@ -142,6 +142,8 @@ export const { Stack } = stackflow({
   ],
 });
 
-export const screenId: Record<string, RegisteredActivityName> = {
-  '1': 'SearchResultScreen',
+type BannerScreen = { [K in keyof Register]: { name: K; params: Register[K] } };
+
+export const bannerScreen: Record<string, BannerScreen[keyof BannerScreen]> = {
+  '1': { name: 'SearchResultScreen', params: { keyword: '', regions: [] } },
 };

--- a/apps/user-front/src/screens/bookmarks/components/BookmarkList.tsx
+++ b/apps/user-front/src/screens/bookmarks/components/BookmarkList.tsx
@@ -52,7 +52,13 @@ export const BookmarkList = () => {
               {bookmark.images && bookmark.images.length > 0 ? (
                 <div className='rounded-[12px] shrink-0 size-[128px] relative overflow-hidden'>
                   {bookmark.images.map((image) => (
-                    <Image key={image.id} src={image.imageUrl} alt={bookmark.name} fill />
+                    <Image
+                      className='object-cover w-full h-full'
+                      key={image.id}
+                      src={image.imageUrl}
+                      alt={bookmark.name}
+                      fill
+                    />
                   ))}
                 </div>
               ) : (

--- a/apps/user-front/src/screens/store-detail/StoreDetail.tsx
+++ b/apps/user-front/src/screens/store-detail/StoreDetail.tsx
@@ -135,7 +135,7 @@ const StoreDetail = ({ storeId, showHeader, initialTab = 'home' }: StoreDetailPr
       <NavButton className='z-10 absolute right-grid-margin top-3'>
         <ShareIcon className='size-5' />
       </NavButton>
-      {store.images && store.images.length === 0 && <StoreImagePlaceholder />}
+      {(store.images === null || store.images.length === 0) && <StoreImagePlaceholder />}
       {store.images && store.images.length > 0 && (
         <StoreImageCarousel imageUrls={store.images.map((image) => image.imageUrl)} />
       )}

--- a/apps/user-front/src/screens/store-detail/components/tabs/Home.tsx
+++ b/apps/user-front/src/screens/store-detail/components/tabs/Home.tsx
@@ -14,6 +14,7 @@ import { MenuCard } from '@/components/Store/MenuCard';
 import { ReviewsList } from '@/components/Store/ReviewsList';
 import { StoresList } from '@/components/Store/StoresList';
 import { SubwayLineBadge } from '@/components/SubwayLineBadge';
+import { useGetStoreImmediateEntryList } from '@/hooks/store/useGetStoreImmediateEntryList';
 import { useGetStoreList } from '@/hooks/store/useGetStoreList';
 import { useGetStoreMenuList } from '@/hooks/store/useGetStoreMenuList';
 import { useGetStoreReviewList } from '@/hooks/store/useGetStoreReviewList';
@@ -43,6 +44,10 @@ export const StoreDetailHomeTab = ({
   const { data: storeMenus } = useGetStoreMenuList(store.id);
   const { data: reviews } = useGetStoreReviewList(store.id);
   const { data: stores } = useGetStoreList({ sortType: 'RECENT' });
+  const { data: immediateEntryStores } = useGetStoreImmediateEntryList({
+    pageNum: 1,
+    pageSize: 10,
+  });
 
   return (
     <div className='flex flex-col'>
@@ -150,10 +155,9 @@ export const StoreDetailHomeTab = ({
           stores={stores.list}
           onClickTotalBtn={noop}
         />
-        {/* TODO: 지금 바로 입장 가능한 식당 목록 조회 기능 추가 */}
         <StoresList
           subtitle='지금 바로 입장하실 수 있어요!'
-          stores={stores.list}
+          stores={immediateEntryStores.list}
           onClickTotalBtn={noop}
         />
       </div>

--- a/apps/user-front/src/tabs/home/Home.tsx
+++ b/apps/user-front/src/tabs/home/Home.tsx
@@ -64,12 +64,9 @@ const ContentBody = () => {
       />
       <div className='bg-white mb-3'>
         <Banner />
+        <CategoryTabs category={category} onCategoryChange={setCategory} />
         <Suspense>
-          <StoreSection
-            selectedRegions={preferredRegions}
-            category={category}
-            onCategoryChange={setCategory}
-          />
+          <StoreSection selectedRegions={preferredRegions} category={category} />
         </Suspense>
       </div>
     </div>
@@ -79,10 +76,9 @@ const ContentBody = () => {
 type StoreSectionProps = {
   selectedRegions: { id: string; name: string }[];
   category: StoreCategory | null;
-  onCategoryChange: (category: StoreCategory | null) => void;
 };
 
-const StoreSection = ({ selectedRegions, category, onCategoryChange }: StoreSectionProps) => {
+const StoreSection = ({ selectedRegions, category }: StoreSectionProps) => {
   const { data: stores } = useGetStoreList({
     pageNum: 1,
     pageSize: 10,
@@ -112,10 +108,7 @@ const StoreSection = ({ selectedRegions, category, onCategoryChange }: StoreSect
 
   return (
     <>
-      <div className='flex flex-col py-grid-margin'>
-        <CategoryTabs category={category} onCategoryChange={onCategoryChange} />
-        <MainStoreList stores={stores.list} />
-      </div>
+      {stores.list.length > 0 && <MainStoreList stores={stores.list} />}
       <Divider />
       <StoresList
         subtitle='푸딩에서 인기 많은 식당이에요'

--- a/apps/user-front/src/tabs/home/components/Banner.tsx
+++ b/apps/user-front/src/tabs/home/components/Banner.tsx
@@ -4,7 +4,7 @@ import { useFlow } from '@stackflow/react/future';
 
 import { Carousel } from '@/components/Carousel';
 import { useGetBannerList } from '@/hooks/banner/useGetBannerList';
-import { screenId } from '@/libs/stackflow';
+import { bannerScreen } from '@/libs/stackflow';
 
 const DEFAULT_PLACEHOLDER = '/images/home/banneritem1.png';
 
@@ -27,10 +27,10 @@ export const Banner = () => {
                 onClick={() => {
                   if (!banner.parameters || !banner.parameters.screenId) return;
 
-                  const screenName = screenId[banner.parameters.screenId];
+                  const screen = bannerScreen[banner.parameters.screenId];
 
-                  if (screenName) {
-                    flow.push(screenName, {});
+                  if (screen) {
+                    flow.push(screen.name, screen.params);
                   }
                 }}
               >

--- a/apps/user-front/src/tabs/home/components/CategoryTabs.tsx
+++ b/apps/user-front/src/tabs/home/components/CategoryTabs.tsx
@@ -7,7 +7,7 @@ interface CategoryTabsProps {
 }
 
 export const CategoryTabs = ({ category, onCategoryChange }: CategoryTabsProps) => (
-  <div className='flex flex-col justify-between px-grid-margin pb-grid-margin gap-4'>
+  <div className='flex flex-col justify-between px-grid-margin py-grid-margin gap-4'>
     <div className='subtitle-1'>오늘은 어디에서 식사할까요?</div>
     <ChipTabs value={category ?? undefined} onChange={onCategoryChange} scrollable>
       <ChipTabs.List>

--- a/apps/user-front/src/tabs/home/components/MainStoreList.tsx
+++ b/apps/user-front/src/tabs/home/components/MainStoreList.tsx
@@ -6,7 +6,6 @@ import { useFlow } from '@stackflow/react/future';
 
 import { isNonEmptyArray } from '@/utils/array';
 
-
 interface MainStoreListProps {
   stores: Store[];
 }
@@ -15,7 +14,7 @@ export const MainStoreList = ({ stores }: MainStoreListProps) => {
   const flow = useFlow();
 
   return (
-    <div className='flex flex-col px-grid-margin bg-white/80'>
+    <div className='flex flex-col px-grid-margin bg-white/80 pb-grid-margin'>
       <ul className='flex gap-3 overflow-x-auto scrollbar-hide -mx-grid-margin px-grid-margin'>
         {stores.map((store) => (
           <li key={store.id} className='flex flex-col relative'>


### PR DESCRIPTION
<!-- 제목: [FE-00] 이슈 제목 -->

## 🎫 관련 티켓
<!-- [이슈 제목](노션 링크) -->
<br />

## 📝 요약(Summary)

- 홈 스크린 Suspense 영역을 분리하여 카테고리 필터 적용 중에 카테고리 탭이 사라지는 버그 수정
- 가게 상세 이미지가 null일 경우 플레이스홀더가 표시되지 않는 버그 수정
- 가게 상세 페이지 에러 UI를 개선하여 에러 발생 시 뒤로가기를 할 수 있도록 수정
- 배너의 스크린 ID와 스크린을 맵필 할 때 해당 스크린의 params도 포함하도록 수정
- 가게 상세 바로 입장 가능한 가게 목록 API가 연동되어있지 않았던 부분 수정

<br />

## 🛠️ PR 유형
<!-- 해당 항목에 'x'를 입력하면 체크됩니다. -->
- [ ] 기능 추가
- [x] 버그 수정
- [x] UI 수정 (스타일, 레이아웃 등)
- [ ] 리팩토링 (동작 변경 없음)
- [ ] 문서 또는 주석 수정
- [ ] 테스트 코드 추가/수정
- [ ] 기타 구조 변경 (폴더명, 빌드 설정 등)  
<br />

## 📸스크린샷 (Optional)

<br />

## 💬 공유사항 to 리뷰어
<!--- 리뷰어가 중점적으로 봐줬으면 좋겠는 부분이 있으면 적어주세요. -->
<!--- 논의해야할 부분이 있다면 적어주세요.-->
<!--- ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요? -->
<br />
